### PR TITLE
Local Development Environment #95958132

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+*.pyc
+include/
+lib/
+staticfiles/
+media/
+.build
+
+# sqlite3 db
+*.db
+*.sqlite3
+
+# sublime stuff
+*.sublime-workspace
+*.sublime-project
+
+# Virtual env
+venv/
+
+# Mac crap
+*.DS_Store
+
+# Node Stuff
+node_modules
+
+mtp_cashbook/assets-src/bower_components
+mtp_cashbook/assets/
+
+# Sass-cache
+.sass-cache

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ The Cashbook UI for the Money to Prisoners Project
 ## Dependencies
 ### Docker
 To run this project locally you need to have 
-[docker](http://docs.docker.com/installation/mac/) and 
-[docker-compose](https://docs.docker.com/compose/install/) installed.
+[Docker](http://docs.docker.com/installation/mac/) and 
+[Docker Compose](https://docs.docker.com/compose/install/) installed.
 
 ### Other Repositories
 Alongside this repository you'll need the [API server](https://github.com/ministryofjustice/money-to-prisoners-api)
 and if you're planning to deploy then you'll need the [deployment repository](https://github.com/ministryofjustice/money-to-prisoners-deploy)
 
-### Development Server
-#### Boot2Docker
+## Development Server
+### Boot2Docker
 > If you're developing on a Mac then Docker won't run natively, you'll be running 
-> a single VM with linux installed where your docker containers run. To start the vm 
+> a single VM with linux installed where your Docker containers run. To start the vm 
 > run the following first before continuing:
 > ```
 > $ boot2docker up
@@ -23,11 +23,10 @@ and if you're planning to deploy then you'll need the [deployment repository](ht
 
 In a terminal `cd` into the directory you checked this project out into, then
 ```
-$ npm install
 $ docker-compose build && docker-compose up
 ```
 
-Wait while docker does it's stuff and you'll soon see something like:
+Wait while Docker does it's stuff and you'll soon see something like:
 ```
 djangogulpserve_1 | [BS] Now you can access your site through the following addresses:
 djangogulpserve_1 | [BS] Local URL: http://localhost:3000
@@ -36,4 +35,4 @@ djangogulpserve_1 | [BS] Local URL: http://localhost:3000
 you should be able to point your browser at
 [http://localhost:3000](http://localhost:3000)
 if you're using *boot2docker* then it'll be at the IP of the boot2docker virtual machine.
-You can find it by typing `boot2docker ip` in a terminal. Then visit http://**boot2docker ip**>:3000/
+You can find it by typing `boot2docker ip` in a terminal. Then visit http://**boot2docker ip**:3000/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Money to Prisoners Cashbook
+The Cashbook UI for the Money to Prisoners Project
+
+## Dependencies
+### Docker
+To run this project locally you need to have 
+[docker](http://docs.docker.com/installation/mac/) and 
+[docker-compose](https://docs.docker.com/compose/install/) installed.
+
+### Other Repositories
+Alongside this repository you'll need the [API server](https://github.com/ministryofjustice/money-to-prisoners-api)
+and if you're planning to deploy then you'll need the [deployment repository](https://github.com/ministryofjustice/money-to-prisoners-deploy)
+
+### Development Server
+#### Boot2Docker
+> If you're developing on a Mac then Docker won't run natively, you'll be running 
+> a single VM with linux installed where your docker containers run. To start the vm 
+> run the following first before continuing:
+> ```
+> $ boot2docker up
+> $ eval "$(boot2docker shellinit)"
+> ```
+
+In a terminal `cd` into the directory you checked this project out into, then
+```
+$ npm install
+$ docker-compose build && docker-compose up
+```
+
+Wait while docker does it's stuff and you'll soon see something like:
+```
+djangogulpserve_1 | [BS] Now you can access your site through the following addresses:
+djangogulpserve_1 | [BS] Local URL: http://localhost:3000
+```
+
+you should be able to point your browser at
+[http://localhost:3000](http://localhost:3000)
+if you're using *boot2docker* then it'll be at the IP of the boot2docker virtual machine.
+You can find it by typing `boot2docker ip` in a terminal. Then visit http://**boot2docker ip**>:3000/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ django:
 
 djangogulpserve:
   build: .
-  command: /bin/bash -c "gulp serve --host=$DJANGO_1_PORT_8001_TCP_ADDR --port=$TESTMOJDJANGO_DJANGO_1_PORT_8001_TCP_PORT"
+  command: /bin/bash -c "npm install --unsafe-perm && gulp serve --host=$DJANGO_1_PORT_8001_TCP_ADDR --port=$TESTMOJDJANGO_DJANGO_1_PORT_8001_TCP_PORT"
   volumes:
     - .:/app
   ports:

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "engines": {
     "node": "0.10.x"
   },
+  "config": {
+    "unsafe-perm": true
+  },
   "scripts": {
-    "start": "node node_modules/.bin/gulp",
-    "postinstall": "node node_modules/bower/bin/bower install"
+    "start": "./node_modules/.bin/gulp serve",
+    "postinstall": "./node_modules/.bin/bower --allow-root install"
   },
   "dependencies": {
     "node-sass": "~0.9.3",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "engines": {
     "node": "0.10.x"
   },
+  "scripts": {
+    "start": "node node_modules/.bin/gulp",
+    "postinstall": "node node_modules/bower/bin/bower install"
+  },
   "dependencies": {
     "node-sass": "~0.9.3",
     "gulp": "^3.8.10",


### PR DESCRIPTION
This allows a developer to run the project and develop locally using `docker-compose` without having to have anything else installed. 

The readme has been updated to show how to do this on a Mac/using boot2docker. 