### PR TITLE
Collect static assets for production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,10 @@ ADD ./requirements/ /app/requirements/
 RUN pip3 install -r requirements/prod.txt
 
 ADD . /app
-RUN bower install --allow-root
+
+RUN npm install --unsafe-perm
+RUN gulp
+RUN ./manage.py collectstatic --noinput
 
 EXPOSE 8080
 CMD ["/usr/local/bin/uwsgi", "--ini", "/etc/uwsgi/magiclantern.ini"]

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -70,7 +70,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.7/howto/static-files/
 
-STATIC_ROOT = 'staticfiles'
+STATIC_ROOT = 'static'
 STATIC_URL = '/static/'
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'assets')

--- a/mtp_cashbook/templates/base.html
+++ b/mtp_cashbook/templates/base.html
@@ -10,7 +10,6 @@
   <link rel="stylesheet" href="{% static "stylesheets/app.css" %}">
   
   {% else %}
-  <link rel="stylesheet" href="{% static "stylesheets/lib.min.css" %}">
   <link rel="stylesheet" href="{% static "stylesheets/app.min.css" %}">
   
   {% endif %}
@@ -26,8 +25,6 @@
   <script src="{% static "javascripts/app.js" %}"></script>
   <script src="//localhost:35729/livereload.js"></script>
   {% else %}
-  <script src="{% static "javascripts/lib.min.js" %}"></script>
-  
   <script src="{% static "javascripts/app.min.js" %}"></script>
   {% endif %}
 


### PR DESCRIPTION
Jenkins needs to be able to extract assets from the container when deploying. To allow it to do that, compile them then collect them all into one place (defined by `mtp_cashbook.settings.*.STATIC_ROOT`).

Because of the way we're deploying them to S3, `STATIC_ROOT` needs to be the same as `STATIC_URL`, or we'll be referring to invalid URLs.

Also use `npm install` instead of `bower install` so that it installs gulp et al. in more accessible paths.