### PR TITLE
Don't set default timezone to be Europe/London

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:trusty
 
-RUN echo "Europe/London" > /etc/timezone  &&  dpkg-reconfigure -f noninteractive tzdata
-
 RUN apt-get update && \
     apt-get install -y software-properties-common python-software-properties
 


### PR DESCRIPTION
After discussing with platofrms team, this isn't a good idea. Their own
docker base images don't do this and we want to be consistent.