### PR TITLE
Make running a local dev environment quicker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,23 @@
 django:
   build: .
-  command: python manage.py runserver 0.0.0.0:8001
+  command: >
+    /bin/bash -c "
+    pip install -r requirements/dev.txt &&
+    python manage.py runserver 0.0.0.0:8001"
   volumes:
     - .:/app
+    - /tmp/pip_download_cache/:/tmp/pip_download_cache
   ports:
     - "8001:8001"
+  environment:
+    PIP_DOWNLOAD_CACHE: /tmp/pip_download_cache/
 
 djangogulpserve:
   build: .
   command: /bin/bash -c "npm install --unsafe-perm && gulp serve --host=$DJANGO_1_PORT_8001_TCP_ADDR --port=$TESTMOJDJANGO_DJANGO_1_PORT_8001_TCP_PORT"
   volumes:
     - .:/app
+    - /tmp/npm/:/root/.npm/
   ports:
     - "3000:3000"
   links:


### PR DESCRIPTION
After setting up a new dev environment for the API server project
I have found some better ways of doing things in a local dev
environment using docker-compose.

 - The docker-compose up command now installed python dev
   dependencies before running the server
 - The npm install command in the gulp container now shares
   a .npm cache with the host
 - PIP now shares a PIP_DOWNLOAD_CACHE with the host so it
   doesn't need to download the same dependencies every
   time