### PR TITLE
Allow users to log into cashbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,13 @@ you should be able to point your browser at
 [http://localhost:3000](http://localhost:3000)
 if you're using *boot2docker* then it'll be at the IP of the boot2docker virtual machine.
 You can find it by typing `boot2docker ip` in a terminal. Then visit http://**boot2docker ip**:3000/
+
+## Login
+
+Make sure you have a version of the [API](https://github.com/ministryofjustice/money-to-prisoners-api) server
+running on port 8000.
+
+You should be able to log into the cash book app using following credentials:
+
+- *test_prison_1 / test_prison_1* for Prison 1
+- *test_prison_2 / test_prison_2* for Prison 2

--- a/mtp_cashbook/apps/core/admin.py
+++ b/mtp_cashbook/apps/core/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/mtp_cashbook/apps/core/tests.py
+++ b/mtp_cashbook/apps/core/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/mtp_cashbook/apps/mtp_auth/__init__.py
+++ b/mtp_cashbook/apps/mtp_auth/__init__.py
@@ -1,0 +1,98 @@
+from django.conf import settings
+from django.contrib.auth.signals import user_logged_in, user_logged_out
+from django.contrib.auth import load_backend
+from django.middleware.csrf import rotate_token
+from django.utils.crypto import constant_time_compare
+from django.utils.translation import LANGUAGE_SESSION_KEY
+
+
+from .models import MtpAnonymousUser
+
+SESSION_KEY = '_auth_user_id'
+BACKEND_SESSION_KEY = '_auth_user_backend'
+HASH_SESSION_KEY = '_auth_user_hash'
+
+
+def login(request, user):
+    """
+    Persist a user id and a backend in the request. This way a user doesn't
+    have to reauthenticate on every request. Note that data set during
+    the anonymous session is retained when the user logs in.
+    """
+    session_auth_hash = ''
+    if user is None:
+        user = request.user
+    if hasattr(user, 'get_session_auth_hash'):
+        session_auth_hash = user.get_session_auth_hash()
+
+    if SESSION_KEY in request.session:
+        session_key = request.session[SESSION_KEY]
+        if session_key != user.pk or (
+                session_auth_hash and
+                request.session.get(HASH_SESSION_KEY) != session_auth_hash):
+            # To avoid reusing another user's session, create a new, empty
+            # session if the existing session corresponds to a different
+            # authenticated user.
+            request.session.flush()
+    else:
+        request.session.cycle_key()
+    request.session[SESSION_KEY] = user.pk
+    request.session[BACKEND_SESSION_KEY] = user.backend
+    request.session[HASH_SESSION_KEY] = session_auth_hash
+    if hasattr(request, 'user'):
+        request.user = user
+    rotate_token(request)
+    user_logged_in.send(sender=user.__class__, request=request, user=user)
+
+
+def get_user(request):
+    """
+    Returns the user model instance associated with the given request session.
+    If no user is retrieved an instance of `MtpAnonymousUser` is returned.
+    """
+    user = None
+    try:
+        user_id = request.session[SESSION_KEY]
+        backend_path = request.session[BACKEND_SESSION_KEY]
+    except KeyError:
+        pass
+    else:
+        if backend_path in settings.AUTHENTICATION_BACKENDS:
+            backend = load_backend(backend_path)
+            user = backend.get_user(user_id)
+            # Verify the session
+            if hasattr(user, 'get_session_auth_hash'):
+                session_hash = request.session.get(HASH_SESSION_KEY)
+                session_hash_verified = session_hash and constant_time_compare(
+                    session_hash,
+                    user.get_session_auth_hash()
+                )
+                if not session_hash_verified:
+                    request.session.flush()
+                    user = None
+
+    return user or MtpAnonymousUser()
+
+
+def logout(request):
+    """
+    Removes the authenticated user's ID from the request and flushes their
+    session data.
+    """
+    # Dispatch the signal before the user is logged out so the receivers have a
+    # chance to find out *who* logged out.
+    user = getattr(request, 'user', None)
+    if hasattr(user, 'is_authenticated') and not user.is_authenticated():
+        user = None
+    user_logged_out.send(sender=user.__class__, request=request, user=user)
+
+    # remember language choice saved to session
+    language = request.session.get(LANGUAGE_SESSION_KEY)
+
+    request.session.flush()
+
+    if language is not None:
+        request.session[LANGUAGE_SESSION_KEY] = language
+
+    if hasattr(request, 'user'):
+        request.user = MtpAnonymousUser()

--- a/mtp_cashbook/apps/mtp_auth/api_client.py
+++ b/mtp_cashbook/apps/mtp_auth/api_client.py
@@ -1,27 +1,91 @@
 import slumber
+from slumber.serialize import Serializer, JsonSerializer
+from requests.auth import AuthBase
 
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
 from django.utils.http import urlencode
 
 
+class BearerTokenAuth(AuthBase):
+    """
+    Attaches the Bearer token to the request.
+    """
+    def __init__(self, token):
+        self.token = token
+
+    def get_header(self):
+        return ('Authorization', 'Bearer %s' % self.token)
+
+    def __call__(self, request):
+        key, token = self.get_header()
+        request.headers[key] = token
+        return request
+
+
 class FormSerializer(slumber.serialize.JsonSerializer):
+    """
+    This FormSerializer has to be used during the authentication
+    process as the `django-oauth-toolkit` version that the api app
+    is using does not support json format yet (currently in master
+    so expected soon).
+    """
     key = "form"
-    content_types = ["application/x-www-form-urlencoded", "application/json"]
+    content_types = ["application/x-www-form-urlencoded"]
 
     def dumps(self, data):
         return urlencode(data)
 
 
-def get_auth_connection():
+def get_raw_connection(token=None, serializer='json'):
     """
     Returns a slumber connection configured so that it can be easily
-    used for authentication.
+    used to query the API server.
+
+    If you have a token:
+        conn = get_raw_connection(token='your-token')
+        conn.my_endpoint.get()
+
+    If you want to authenticate as you don't have a token:
+        conn = get_raw_connection(serializer='form')
+        conn.connection.oauth2.token.post({
+            'client_id': 'client-id',
+            'client_secret': 'client-secret',
+            'grant_type': 'password',
+            'username': 'my-username',
+            'password': 'my-password'
+        })
+
+    If you have a request object and a logged-in user, you might want to use
+    this other shortcut function instead:
+        get_connection(request).my_endpoint.get()
     """
-    s = slumber.serialize.Serializer(
-        default="form",
+    auth = BearerTokenAuth(token) if token else None
+
+    s = Serializer(
+        default=serializer,
         serializers=[
             FormSerializer(),
+            JsonSerializer()
         ]
     )
 
-    return slumber.API(settings.API_URL, serializer=s)
+    return slumber.API(settings.API_URL, serializer=s, auth=auth)
+
+
+def get_connection(request):
+    """
+    Returns a slumber connection configured using the token of the
+    logged-in user.
+
+    It raises `django.core.exceptions.PermissionDenied` if the user
+    is not authenticated.
+
+        response = get_connection(request).my_endpoint.get()
+    """
+    user = request.user
+
+    if not user:
+        raise PermissionDenied(u'no such user')
+
+    return get_raw_connection(user.pk)

--- a/mtp_cashbook/apps/mtp_auth/api_client.py
+++ b/mtp_cashbook/apps/mtp_auth/api_client.py
@@ -1,0 +1,27 @@
+import slumber
+
+from django.conf import settings
+from django.utils.http import urlencode
+
+
+class FormSerializer(slumber.serialize.JsonSerializer):
+    key = "form"
+    content_types = ["application/x-www-form-urlencoded", "application/json"]
+
+    def dumps(self, data):
+        return urlencode(data)
+
+
+def get_auth_connection():
+    """
+    Returns a slumber connection configured so that it can be easily
+    used for authentication.
+    """
+    s = slumber.serialize.Serializer(
+        default="form",
+        serializers=[
+            FormSerializer(),
+        ]
+    )
+
+    return slumber.API(settings.API_URL, serializer=s)

--- a/mtp_cashbook/apps/mtp_auth/backends.py
+++ b/mtp_cashbook/apps/mtp_auth/backends.py
@@ -6,7 +6,7 @@ from slumber.exceptions import HttpClientError
 
 from django.conf import settings
 
-from .api_client import get_auth_connection
+from .api_client import get_raw_connection
 from .models import MtpUser
 from .exceptions import ConnectionError
 
@@ -28,7 +28,7 @@ class MtpBackend(object):
         It raises `mtp_auth.exceptions.ConnetionError` in case of
         problems connecting to the api server.
         """
-        connection = get_auth_connection()
+        connection = get_raw_connection(serializer='form')
         try:
             response = connection.oauth2.token.post({
                 'client_id': settings.API_CLIENT_ID,

--- a/mtp_cashbook/apps/mtp_auth/backends.py
+++ b/mtp_cashbook/apps/mtp_auth/backends.py
@@ -1,0 +1,52 @@
+import json
+import logging
+
+from requests import ConnectionError as RequestsConnectionError
+from slumber.exceptions import HttpClientError
+
+from django.conf import settings
+
+from .api_client import get_auth_connection
+from .models import MtpUser
+from .exceptions import ConnectionError
+
+logger = logging.getLogger(__name__)
+
+
+class MtpBackend(object):
+    """
+    Django authentication backend which authenticates against the api
+    server using oauth2.
+
+    Client Id and Secret can be changed in settings.
+    """
+    def authenticate(self, username=None, password=None):
+        """
+        Returns a valid `MtpUser` if the authentication is successful
+        or None if the credentials were wrong.
+
+        It raises `mtp_auth.exceptions.ConnetionError` in case of
+        problems connecting to the api server.
+        """
+        connection = get_auth_connection()
+        try:
+            response = connection.oauth2.token.post({
+                'client_id': settings.API_CLIENT_ID,
+                'client_secret': settings.API_CLIENT_SECRET,
+                'grant_type': 'password',
+                'username': username,
+                'password': password
+            })
+        except RequestsConnectionError as e:
+            logger.error('Cannot connect with the API')
+            raise ConnectionError(e)
+        except HttpClientError as hcerr:
+            error = json.loads(hcerr.content.decode())
+            logger.error(error.get('description'))
+            return
+
+        user = MtpUser(response['access_token'])
+        return user
+
+    def get_user(self, token):
+        return MtpUser(token)

--- a/mtp_cashbook/apps/mtp_auth/exceptions.py
+++ b/mtp_cashbook/apps/mtp_auth/exceptions.py
@@ -1,0 +1,6 @@
+class ConnectionError(Exception):
+    """
+    Exception that should be raised in case of connection
+    problems with the api server.
+    """
+    pass

--- a/mtp_cashbook/apps/mtp_auth/forms.py
+++ b/mtp_cashbook/apps/mtp_auth/forms.py
@@ -1,0 +1,53 @@
+from django import forms
+from django.contrib.auth import authenticate
+
+from django.utils.translation import ugettext_lazy as _
+
+from .exceptions import ConnectionError
+
+
+class AuthenticationForm(forms.Form):
+    """
+    Authentication form used for authenticating users during the login process.
+    """
+    username = forms.CharField(label=_("Username"), max_length=254)
+    password = forms.CharField(label=_("Password"), widget=forms.PasswordInput)
+
+    error_messages = {
+        'invalid_login': _("Please enter a correct username and password. "
+                           "Note that both fields may be case-sensitive."),
+        'connection_error': _("The API Server seems down, please try again later."),
+    }
+
+    def __init__(self, request=None, *args, **kwargs):
+        self.request = request
+        self.user_cache = None
+        super(AuthenticationForm, self).__init__(*args, **kwargs)
+
+    def clean(self):
+        username = self.cleaned_data.get('username')
+        password = self.cleaned_data.get('password')
+
+        if username and password:
+            try:
+                self.user_cache = authenticate(
+                    username=username, password=password
+                )
+                # if authenticate returns None it means that the
+                # credentials were wront
+                if self.user_cache is None:
+                    raise forms.ValidationError(
+                        self.error_messages['invalid_login'],
+                        code='invalid_login',
+                    )
+            except ConnectionError:
+                # in case of problems connecting to the api server
+                raise forms.ValidationError(
+                        self.error_messages['connection_error'],
+                        code='connection_error',
+                    )
+
+        return self.cleaned_data
+
+    def get_user(self):
+        return self.user_cache

--- a/mtp_cashbook/apps/mtp_auth/middleware.py
+++ b/mtp_cashbook/apps/mtp_auth/middleware.py
@@ -1,0 +1,23 @@
+from django.utils.functional import SimpleLazyObject
+
+from . import get_user as auth_get_user
+
+
+def get_user(request):
+    """
+    Returns a cached copy of the user if it exists or calls `auth_get_user`
+    otherwise.
+    """
+    if not hasattr(request, '_cached_user'):
+        request._cached_user = auth_get_user(request)
+    return request._cached_user
+
+
+class AuthenticationMiddleware(object):
+    """
+    It simply sets `request.user` so that it can be used in our views.
+
+    The build-in Django one sadly tries to get the user from the database.
+    """
+    def process_request(self, request):
+        request.user = SimpleLazyObject(lambda: get_user(request))

--- a/mtp_cashbook/apps/mtp_auth/models.py
+++ b/mtp_cashbook/apps/mtp_auth/models.py
@@ -1,0 +1,29 @@
+class MtpUser(object):
+    """
+    Authenticated user, similar to the Django one.
+
+    The built-in Django `AbstractBaseUser` sadly depends on a few tables and
+    cannot be used without a datbase so we had to create a custom one.
+    """
+    def __init__(self, token):
+        self.pk = token
+        self.is_active = True
+
+    def save(self, *args, **kwargs):
+        pass
+
+    def is_authenticated(self, *args, **kwargs):
+        return True
+
+
+class MtpAnonymousUser(object):
+    """
+    Anonymous non-authenticated user, similar to the Django one.
+
+    The built-in Django `AnonymousUser` sadly depends on a few tables and
+    gives several warnings when used without a database so we had to create a
+    custom one.
+    """
+
+    def is_authenticated(self, *args, **kwargs):
+        return False

--- a/mtp_cashbook/apps/mtp_auth/tests/test_forms.py
+++ b/mtp_cashbook/apps/mtp_auth/tests/test_forms.py
@@ -1,0 +1,76 @@
+import mock
+
+from django.test.testcases import SimpleTestCase
+from django.utils.encoding import force_text
+
+from mtp_auth.exceptions import ConnectionError
+from mtp_auth.forms import AuthenticationForm
+
+
+class AuthenticationFormTest(SimpleTestCase):
+    """
+    Tests that the AuthenticationForm manages valid/invalid
+    credentials and problems with the api.
+    """
+
+    @mock.patch('mtp_auth.forms.authenticate')
+    def __call__(self, result, mocked_authenticate, *args, **kwargs):
+        """
+        Mocks the `authenticate` method so that we can use it
+        everywhere in our test methods.
+        """
+        self.mocked_authenticate = mocked_authenticate
+        super(AuthenticationFormTest, self).__call__(result, *args, **kwargs)
+
+    def setUp(self):
+        super(AuthenticationFormTest, self).setUp()
+        self.credentials = {
+            'username': 'testclient',
+            'password': 'password',
+        }
+
+    def test_invalid_credentials(self):
+        """
+        The User submits invalid credentials
+        """
+        self.mocked_authenticate.return_value = None
+
+        data = {
+            'username': 'jsmith_does_not_exist',
+            'password': 'test123',
+        }
+
+        form = AuthenticationForm(data=data)
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.non_field_errors(),
+            [force_text(form.error_messages['invalid_login'])]
+        )
+
+        self.mocked_authenticate.assert_called_with(**data)
+
+    def test_success(self):
+        """
+        Successful authentication.
+        """
+        self.mocked_authenticate.return_value = mock.MagicMock()
+
+        form = AuthenticationForm(data=self.credentials)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.non_field_errors(), [])
+
+        self.mocked_authenticate.assert_called_with(**self.credentials)
+
+    def test_api_connection_error(self):
+        """
+        The app cannot connect to the api server.
+        """
+        self.mocked_authenticate.side_effect = ConnectionError()
+
+        form = AuthenticationForm(data=self.credentials)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.non_field_errors(),
+            [force_text(form.error_messages['connection_error'])]
+        )

--- a/mtp_cashbook/apps/mtp_auth/tests/test_views.py
+++ b/mtp_cashbook/apps/mtp_auth/tests/test_views.py
@@ -1,0 +1,112 @@
+import mock
+
+from requests import ConnectionError
+
+from django.conf import settings
+from django.contrib.auth import SESSION_KEY, BACKEND_SESSION_KEY
+from django.core.urlresolvers import reverse
+from django.test import SimpleTestCase
+from django.utils.encoding import force_text
+
+from slumber.exceptions import HttpClientError
+
+
+class LoginViewTestCase(SimpleTestCase):
+    """
+    Tests that the login flow works as expected.
+    """
+
+    @mock.patch('mtp_auth.backends.get_auth_connection')
+    def __call__(
+        self, result,
+        mocked_get_auth_connection,
+        *args, **kwargs
+    ):
+        """
+        Mocks the connection with the api so that we can control it
+        everywhere in our test methods.
+        """
+        self.mocked_get_auth_connection = mocked_get_auth_connection
+        super(LoginViewTestCase, self).__call__(result, *args, **kwargs)
+
+    def setUp(self, *args, **kwargs):
+        super(LoginViewTestCase, self).setUp(*args, **kwargs)
+
+        self.credentials = {
+            'username': 'my-username',
+            'password': 'my-password'
+        }
+        self.login_url = reverse(u'auth:login')
+        self.logout_url = reverse(u'auth:logout')
+
+    def test_success(self):
+        """
+        Successful authentication.
+        """
+        # mocking the connection so that it returns a valid access token
+        token = '123456789'
+        connection = mock.MagicMock()
+        connection.oauth2.token.post.return_value = {
+            'access_token': token
+        }
+        self.mocked_get_auth_connection.return_value = connection
+
+        # login
+        response = self.client.post(
+            self.login_url, data=self.credentials, follow=True
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.client.session[SESSION_KEY], token)
+        self.assertEqual(
+            self.client.session[BACKEND_SESSION_KEY],
+            settings.AUTHENTICATION_BACKENDS[0]
+        )
+
+        # logout
+        response = self.client.post(self.logout_url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(self.client.session.items()), 0)  # nothing in the session
+
+    def test_invalid_credentials(self):
+        """
+        The User submits invalid credentials
+        """
+        # mocking the connection so that it returns invalid credentials
+        self.mocked_get_auth_connection().oauth2.token.post.side_effect = HttpClientError(
+            content=b'{"description": "invalid credentials"}'
+        )
+
+        response = self.client.post(
+            self.login_url, data={
+                'username': 'my-username',
+                'password': 'wrong-password'
+            }, follow=True
+        )
+
+        form = response.context_data['form']
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors['__all__'],
+            [force_text(form.error_messages['invalid_login'])]
+        )
+        self.assertEqual(len(self.client.session.items()), 0)  # nothing in the session
+
+    def test_api_connection_error(self):
+        """
+        The app cannot connect to the api server.
+        """
+        # mocking the connection so that it raises ConnectionError
+        self.mocked_get_auth_connection().oauth2.token.post.side_effect = ConnectionError()
+
+        response = self.client.post(
+            self.login_url, data=self.credentials, follow=True
+        )
+
+        form = response.context_data['form']
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors['__all__'],
+            [force_text(form.error_messages['connection_error'])]
+        )
+        self.assertEqual(len(self.client.session.items()), 0)  # nothing in the session

--- a/mtp_cashbook/apps/mtp_auth/tests/test_views.py
+++ b/mtp_cashbook/apps/mtp_auth/tests/test_views.py
@@ -16,17 +16,17 @@ class LoginViewTestCase(SimpleTestCase):
     Tests that the login flow works as expected.
     """
 
-    @mock.patch('mtp_auth.backends.get_auth_connection')
+    @mock.patch('mtp_auth.backends.get_raw_connection')
     def __call__(
         self, result,
-        mocked_get_auth_connection,
+        mocked_get_raw_connection,
         *args, **kwargs
     ):
         """
         Mocks the connection with the api so that we can control it
         everywhere in our test methods.
         """
-        self.mocked_get_auth_connection = mocked_get_auth_connection
+        self.mocked_get_raw_connection = mocked_get_raw_connection
         super(LoginViewTestCase, self).__call__(result, *args, **kwargs)
 
     def setUp(self, *args, **kwargs):
@@ -49,7 +49,7 @@ class LoginViewTestCase(SimpleTestCase):
         connection.oauth2.token.post.return_value = {
             'access_token': token
         }
-        self.mocked_get_auth_connection.return_value = connection
+        self.mocked_get_raw_connection.return_value = connection
 
         # login
         response = self.client.post(
@@ -73,7 +73,7 @@ class LoginViewTestCase(SimpleTestCase):
         The User submits invalid credentials
         """
         # mocking the connection so that it returns invalid credentials
-        self.mocked_get_auth_connection().oauth2.token.post.side_effect = HttpClientError(
+        self.mocked_get_raw_connection().oauth2.token.post.side_effect = HttpClientError(
             content=b'{"description": "invalid credentials"}'
         )
 
@@ -97,7 +97,7 @@ class LoginViewTestCase(SimpleTestCase):
         The app cannot connect to the api server.
         """
         # mocking the connection so that it raises ConnectionError
-        self.mocked_get_auth_connection().oauth2.token.post.side_effect = ConnectionError()
+        self.mocked_get_raw_connection().oauth2.token.post.side_effect = ConnectionError()
 
         response = self.client.post(
             self.login_url, data=self.credentials, follow=True

--- a/mtp_cashbook/apps/mtp_auth/urls.py
+++ b/mtp_cashbook/apps/mtp_auth/urls.py
@@ -1,0 +1,11 @@
+from django.conf.urls import patterns, url
+from django.core.urlresolvers import reverse_lazy
+
+
+urlpatterns = patterns('',
+    url(r'^login/$', 'mtp_auth.views.login', name='login'),
+    url(r'^logout/$', 'mtp_auth.views.logout', {
+            'next_page': reverse_lazy('auth:login')
+        }, name='logout'
+    ),
+)

--- a/mtp_cashbook/apps/mtp_auth/views.py
+++ b/mtp_cashbook/apps/mtp_auth/views.py
@@ -1,0 +1,101 @@
+from django.conf import settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.sites.shortcuts import get_current_site
+from django.http import HttpResponseRedirect
+from django.shortcuts import resolve_url
+from django.template.response import TemplateResponse
+from django.utils.http import is_safe_url
+from django.utils.translation import ugettext as _
+from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_protect
+from django.views.decorators.debug import sensitive_post_parameters
+
+from . import login as auth_login
+from . import logout as auth_logout
+from .forms import AuthenticationForm
+
+
+@sensitive_post_parameters()
+@csrf_protect
+@never_cache
+def login(request, template_name='mtp_auth/login.html',
+          redirect_field_name=REDIRECT_FIELD_NAME,
+          authentication_form=AuthenticationForm,
+          current_app=None, extra_context=None):
+    """
+    Displays the login form and handles the login action.
+    """
+    redirect_to = request.POST.get(
+        redirect_field_name,
+        request.GET.get(redirect_field_name, '')
+    )
+
+    if request.method == "POST":
+        form = authentication_form(request, data=request.POST)
+        if form.is_valid():
+
+            # Ensure the user-originating redirection url is safe.
+            if not is_safe_url(url=redirect_to, host=request.get_host()):
+                redirect_to = resolve_url(settings.LOGIN_REDIRECT_URL)
+
+            # Okay, security check complete. Log the user in.
+            auth_login(request, form.get_user())
+
+            return HttpResponseRedirect(redirect_to)
+    else:
+        form = authentication_form(request)
+
+    current_site = get_current_site(request)
+
+    context = {
+        'form': form,
+        redirect_field_name: redirect_to,
+        'site': current_site,
+        'site_name': current_site.name,
+    }
+    if extra_context is not None:
+        context.update(extra_context)
+
+    if current_app is not None:
+        request.current_app = current_app
+
+    return TemplateResponse(request, template_name, context)
+
+
+def logout(request, next_page=None,
+           template_name='mtp_auth/login.html',
+           redirect_field_name=REDIRECT_FIELD_NAME,
+           current_app=None, extra_context=None):
+    """
+    Logs out the user.
+    """
+    auth_logout(request)
+
+    if next_page is not None:
+        next_page = resolve_url(next_page)
+
+    if (redirect_field_name in request.POST or
+            redirect_field_name in request.GET):
+        next_page = request.POST.get(redirect_field_name,
+                                     request.GET.get(redirect_field_name))
+        # Security check -- don't allow redirection to a different host.
+        if not is_safe_url(url=next_page, host=request.get_host()):
+            next_page = request.path
+
+    if next_page:
+        # Redirect to this page until the session has been cleared.
+        return HttpResponseRedirect(next_page)
+
+    current_site = get_current_site(request)
+    context = {
+        'site': current_site,
+        'site_name': current_site.name,
+        'title': _('Logged out')
+    }
+    if extra_context is not None:
+        context.update(extra_context)
+
+    if current_app is not None:
+        request.current_app = current_app
+
+    return TemplateResponse(request, template_name, context)

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -9,11 +9,13 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 """
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+import sys
 import os
 
 from django.conf import global_settings
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
+sys.path.insert(0, os.path.join(BASE_DIR, 'apps'))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
@@ -29,21 +31,23 @@ SECRET_KEY = 'CHANGE_ME'
 # Application definition
 
 INSTALLED_APPS = (
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'mtp_cashbook.apps.core',
 )
+
+PROJECT_APPS = (
+    'core',
+    'mtp_auth'
+)
+
+INSTALLED_APPS += PROJECT_APPS
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'mtp_auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
@@ -123,6 +127,22 @@ TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
 
 DATABASES = {}
 
+
+# AUTH
+SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
+
+AUTH_USER_MODEL = 'mtp_auth.MtpUser'
+
+AUTHENTICATION_BACKENDS = (
+    'mtp_auth.backends.MtpBackend',
+)
+
+API_CLIENT_ID = 'cashbook'
+API_CLIENT_SECRET = os.environ.get('API_CLIENT_SECRET', 'cashbook')
+API_URL = os.environ.get('API_URL', 'http://localhost:8000')
+
+LOGIN_URL = 'auth:login'
+LOGIN_REDIRECT_URL = 'index'
 
 
 try:

--- a/mtp_cashbook/templates/base.html
+++ b/mtp_cashbook/templates/base.html
@@ -6,12 +6,12 @@
   <title>{% block title %}mtp_cashbook{% endblock title %} | mtp_cashbook</title>
   {% load staticfiles %}
   {% if DEBUG %}
-  
+
   <link rel="stylesheet" href="{% static "stylesheets/app.css" %}">
-  
+
   {% else %}
   <link rel="stylesheet" href="{% static "stylesheets/app.min.css" %}">
-  
+
   {% endif %}
   {% block head %}
   {% endblock head %}
@@ -21,7 +21,7 @@
   {% endblock content %}
 
   {% if DEBUG %}
-  
+
   <script src="{% static "javascripts/app.js" %}"></script>
   <script src="//localhost:35729/livereload.js"></script>
   {% else %}

--- a/mtp_cashbook/templates/core/index.html
+++ b/mtp_cashbook/templates/core/index.html
@@ -6,10 +6,9 @@
 <div class="row">
   <div class="small-12 columns moj-wrapper">
     <h1>
-      Yo MoJ222!&nbsp;
-      <a href="//github.com/mixxorz/generator-moj-django/"><i class="fa fa-github"></i></a>
+      You are logged in!
     </h1>
-    <p>Welcome to your MoJ Django app.</p>
+    <p><a href="{% url 'auth:logout' %}">Log out</a></p>
   </div>
 </div>
 {% endblock content %}

--- a/mtp_cashbook/templates/mtp_auth/login.html
+++ b/mtp_cashbook/templates/mtp_auth/login.html
@@ -1,9 +1,9 @@
-{% extends "base.html" %}
+{% extends "base.html" %}{% load i18n %}
 
 {% block content %}
 {% if form.errors and not form.non_field_errors %}
 <p class="errornote">
-{% if form.errors.items|length == 1 %}Please correct the error below.{% else %}Please correct the errors below{% endif %}
+{% if form.errors.items|length == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}
 </p>
 {% endif %}
 
@@ -26,9 +26,8 @@
     {{ form.password.label_tag }} {{ form.password }}
     <input type="hidden" name="next" value="{{ next }}" />
   </div>
-  {% url 'admin_password_reset' as password_reset_url %}
   <div class="submit-row">
-    <label>&nbsp;</label><input type="submit" value="Log in" />
+    <label>&nbsp;</label><input type="submit" value="{% trans 'Log in' %}" />
   </div>
 </form>
 

--- a/mtp_cashbook/templates/mtp_auth/login.html
+++ b/mtp_cashbook/templates/mtp_auth/login.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block content %}
+{% if form.errors and not form.non_field_errors %}
+<p class="errornote">
+{% if form.errors.items|length == 1 %}Please correct the error below.{% else %}Please correct the errors below{% endif %}
+</p>
+{% endif %}
+
+{% if form.non_field_errors %}
+{% for error in form.non_field_errors %}
+<p class="errornote">
+    {{ error }}
+</p>
+{% endfor %}
+{% endif %}
+
+<div id="content-main">
+<form action="{{ app_path }}" method="post" id="login-form">{% csrf_token %}
+  <div class="form-row">
+    {{ form.username.errors }}
+    {{ form.username.label_tag }} {{ form.username }}
+  </div>
+  <div class="form-row">
+    {{ form.password.errors }}
+    {{ form.password.label_tag }} {{ form.password }}
+    <input type="hidden" name="next" value="{{ next }}" />
+  </div>
+  {% url 'admin_password_reset' as password_reset_url %}
+  <div class="submit-row">
+    <label>&nbsp;</label><input type="submit" value="Log in" />
+  </div>
+</form>
+
+<script type="text/javascript">
+document.getElementById('id_username').focus()
+</script>
+</div>
+{% endblock content %}

--- a/mtp_cashbook/urls.py
+++ b/mtp_cashbook/urls.py
@@ -1,12 +1,15 @@
 from django.conf.urls import patterns, include, url
-from django.contrib import admin
+from django.contrib.auth.decorators import login_required
 from django.views.generic.base import TemplateView
 
 urlpatterns = patterns('',
     # Examples:
     # url(r'^$', 'mtp_cashbook.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),
-    url(r'^$', TemplateView.as_view(template_name='core/index.html')),
+    url(r'^$', login_required(
+            TemplateView.as_view(template_name='core/index.html')
+        ), name='index'
+    ),
 
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^auth/', include('mtp_auth.urls', namespace='auth',)),
 )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,3 @@
 # Place your base dependencies here
 Django==1.8.2
+slumber==0.7.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,2 +1,3 @@
 # Place your development dependencies here
 -r base.txt
+mock==1.0.1


### PR DESCRIPTION
This allows a valid user to log into the cashbook app using oauth2 against the API app.

Custom login, logout and authentication logic is required as the standard django behaviour
relies on database tables.
Unfortunately, I had to borrow some django code and change it accordingly in order to support our authentication method.

Use the mock python library for mocking the API connection so that unit tests can run
without dependencies.