### PR TITLE
Pass the host's API_URL to the cashbook container

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ In a terminal `cd` into the directory you checked this project out into, then
 $ docker-compose build && docker-compose up
 ```
 
+If running under boot2docker, be sure to pass the `API_URL` to
+`docker-compose` when starting the containers:
+
+```
+$ docker-compose build && API_URL=http://`boot2docker ip`:8000 docker-compose up
+```
+
 Wait while Docker does it's stuff and you'll soon see something like:
 ```
 djangogulpserve_1 | [BS] Now you can access your site through the following addresses:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ django:
     - "8001:8001"
   environment:
     PIP_DOWNLOAD_CACHE: /tmp/pip_download_cache/
+    API_URL:
 
 djangogulpserve:
   build: .


### PR DESCRIPTION
When running in docker-compose with boot2docker, the cashbook attempts to connect to the default API URL (`http://localhost:8000`) but fails because `localhost` refers to the current container.

To resolve that, we need to pass the `API_URL` environment variable with the boot2docker VM's IP into the container. By specifying `API_URL` in `docker-compose.yml` with no value, docker-compose will read the value from the host, if it exists, and pass that to the container.