### PR TITLE
Refactor api_client to support refresh tokens automatically.

### DIFF
--- a/mtp_cashbook/apps/mtp_auth/__init__.py
+++ b/mtp_cashbook/apps/mtp_auth/__init__.py
@@ -9,8 +9,13 @@ from django.utils.translation import LANGUAGE_SESSION_KEY
 from .models import MtpAnonymousUser
 
 SESSION_KEY = '_auth_user_id'
+AUTH_TOKEN_SESSION_KEY = '_auth_user_auth_token'
 BACKEND_SESSION_KEY = '_auth_user_backend'
 HASH_SESSION_KEY = '_auth_user_hash'
+
+
+def update_token_in_session(request, token):
+    request.session[AUTH_TOKEN_SESSION_KEY] = token
 
 
 def login(request, user):
@@ -39,6 +44,9 @@ def login(request, user):
     request.session[SESSION_KEY] = user.pk
     request.session[BACKEND_SESSION_KEY] = user.backend
     request.session[HASH_SESSION_KEY] = session_auth_hash
+
+    update_token_in_session(request, user.token)
+
     if hasattr(request, 'user'):
         request.user = user
     rotate_token(request)
@@ -53,13 +61,14 @@ def get_user(request):
     user = None
     try:
         user_id = request.session[SESSION_KEY]
+        token = request.session[AUTH_TOKEN_SESSION_KEY]
         backend_path = request.session[BACKEND_SESSION_KEY]
     except KeyError:
         pass
     else:
         if backend_path in settings.AUTHENTICATION_BACKENDS:
             backend = load_backend(backend_path)
-            user = backend.get_user(user_id)
+            user = backend.get_user(user_id, token)
             # Verify the session
             if hasattr(user, 'get_session_auth_hash'):
                 session_hash = request.session.get(HASH_SESSION_KEY)

--- a/mtp_cashbook/apps/mtp_auth/exceptions.py
+++ b/mtp_cashbook/apps/mtp_auth/exceptions.py
@@ -1,6 +1,0 @@
-class ConnectionError(Exception):
-    """
-    Exception that should be raised in case of connection
-    problems with the api server.
-    """
-    pass

--- a/mtp_cashbook/apps/mtp_auth/forms.py
+++ b/mtp_cashbook/apps/mtp_auth/forms.py
@@ -3,8 +3,6 @@ from django.contrib.auth import authenticate
 
 from django.utils.translation import ugettext_lazy as _
 
-from .exceptions import ConnectionError
-
 
 class AuthenticationForm(forms.Form):
     """

--- a/mtp_cashbook/apps/mtp_auth/models.py
+++ b/mtp_cashbook/apps/mtp_auth/models.py
@@ -5,9 +5,13 @@ class MtpUser(object):
     The built-in Django `AbstractBaseUser` sadly depends on a few tables and
     cannot be used without a datbase so we had to create a custom one.
     """
-    def __init__(self, token):
-        self.pk = token
+
+    def __init__(self, username, token={}):
+        self.pk = username
+        self.username = username
         self.is_active = True
+
+        self.token = token
 
     def save(self, *args, **kwargs):
         pass

--- a/mtp_cashbook/apps/mtp_auth/tests/test_api_client.py
+++ b/mtp_cashbook/apps/mtp_auth/tests/test_api_client.py
@@ -68,7 +68,7 @@ class AuthenticateTestCase(SimpleTestCase):
             )
 
 
-class GetConnetionTestCase(SimpleTestCase):
+class GetConnectionTestCase(SimpleTestCase):
 
     def setUp(self):
         """
@@ -78,7 +78,7 @@ class GetConnetionTestCase(SimpleTestCase):
         It also defines the {base_url}/test/ endpoint which will be
         used by all the test methods.
         """
-        super(GetConnetionTestCase, self).setUp()
+        super(GetConnectionTestCase, self).setUp()
         self.request = mock.MagicMock(
             user=mock.MagicMock(
                 token=generate_tokens()

--- a/mtp_cashbook/apps/mtp_auth/tests/test_api_client.py
+++ b/mtp_cashbook/apps/mtp_auth/tests/test_api_client.py
@@ -1,0 +1,177 @@
+import mock
+import json
+import responses
+import datetime
+
+from django.conf import settings
+from django.core.exceptions import PermissionDenied
+from django.test.testcases import SimpleTestCase
+
+from mtp_auth.api_client import REQUEST_TOKEN_URL, authenticate, get_connection
+
+from .utils import generate_tokens
+
+
+class AuthenticateTestCase(SimpleTestCase):
+
+    @responses.activate
+    def test_invalid_credentials(self):
+        # mock the response, return 401
+        responses.add(
+            responses.POST,
+            REQUEST_TOKEN_URL,
+            status=401,
+            content_type='application/json'
+        )
+
+        # authenticate, should return None
+        token = authenticate(
+            'my-username', 'invalid-password'
+        )
+
+        self.assertEqual(token, None)
+
+    @responses.activate
+    def test_success(self):
+        # mock the response, return token
+        expected_token = generate_tokens()
+
+        responses.add(
+            responses.POST,
+            REQUEST_TOKEN_URL,
+            body=json.dumps(expected_token),
+            status=200,
+            content_type='application/json'
+        )
+
+        # authenticate, should return same generated token
+        token = authenticate(
+            'my-username', 'my-password'
+        )
+
+        self.assertDictEqual(token, expected_token)
+
+    def test_error_if_http_instead_of_https(self):
+        """
+        Test that if env var OAUTHLIB_INSECURE_TRANSPORT == False
+        `authenticate` raises an exception if accessing the api
+        using http instead of https.
+        """
+        from oauthlib.oauth2.rfc6749.errors import InsecureTransportError
+
+        with mock.patch.dict(
+            'os.environ', {'OAUTHLIB_INSECURE_TRANSPORT': ''}
+        ):
+            self.assertRaises(
+                InsecureTransportError, authenticate,
+                'my-username', 'my-password'
+            )
+
+
+class GetConnetionTestCase(SimpleTestCase):
+
+    def setUp(self):
+        """
+        Sets up a request mock object with
+        request.user.token == generated token.
+
+        It also defines the {base_url}/test/ endpoint which will be
+        used by all the test methods.
+        """
+        super(GetConnetionTestCase, self).setUp()
+        self.request = mock.MagicMock(
+            user=mock.MagicMock(
+                token=generate_tokens()
+            )
+        )
+
+        self.test_endpoint = '{base_url}/test/'.format(
+            base_url=settings.API_URL
+        )
+
+    def test_fail_without_logged_in_user(self):
+        """
+        If request.user is None, the get_connection raises
+        PermissionDenied.
+        """
+        self.request.user = None
+
+        self.assertRaises(
+            PermissionDenied, get_connection, self.request
+        )
+
+    @responses.activate
+    def test_with_valid_access_token(self):
+        # mock the response, return valid body
+        expected_response = {'success': True}
+
+        responses.add(
+            responses.GET,
+            self.test_endpoint,
+            body=json.dumps(expected_response),
+            status=200,
+            content_type='application/json'
+        )
+
+        # should return the same generated body
+        conn = get_connection(self.request)
+        result = conn.test.get()
+
+        self.assertDictEqual(result, expected_response)
+
+    @responses.activate
+    def test_token_refreshed_automatically(self):
+        """
+        Test that if I call the /test/ endpoint with an
+        expired access token, the module should automatically:
+
+        - request a new access token
+        - update request.user.token to the new token
+        - finally request /test/ with the new valid token
+        """
+        def build_expires_at(dt):
+            return (
+                dt - datetime.datetime(1970, 1, 1)
+            ).total_seconds()
+
+        # dates
+        now = datetime.datetime.now()
+        one_day_delta = datetime.timedelta(days=1)
+
+        expired_yesterday = build_expires_at(now-one_day_delta)
+        expires_tomorrow = build_expires_at(now+one_day_delta)
+
+        # set access_token.expires_at to yesterday
+        self.request.user.token['expires_at'] = expired_yesterday
+        expired_token = self.request.user.token
+
+        # mock the refresh token endpoint, return a new token
+        new_token = generate_tokens(expires_at=expires_tomorrow)
+        responses.add(
+            responses.POST,
+            REQUEST_TOKEN_URL,
+            body=json.dumps(new_token),
+            status=200,
+            content_type='application/json'
+        )
+
+        # mock the /test/ endpoint, return valid body
+        expected_response = {'success': True}
+        responses.add(
+            responses.GET,
+            self.test_endpoint,
+            body=json.dumps(expected_response),
+            status=200,
+            content_type='application/json'
+        )
+
+        # test
+        conn = get_connection(self.request)
+        result = conn.test.get()
+
+        self.assertDictEqual(result, expected_response)
+        self.assertDictEqual(self.request.user.token, new_token)
+        self.assertNotEqual(
+            expired_token['access_token'],
+            new_token['access_token']
+        )

--- a/mtp_cashbook/apps/mtp_auth/tests/test_forms.py
+++ b/mtp_cashbook/apps/mtp_auth/tests/test_forms.py
@@ -3,37 +3,31 @@ import mock
 from django.test.testcases import SimpleTestCase
 from django.utils.encoding import force_text
 
-from mtp_auth.exceptions import ConnectionError
 from mtp_auth.forms import AuthenticationForm
 
 
-class AuthenticationFormTest(SimpleTestCase):
+@mock.patch('mtp_auth.forms.authenticate')
+class AuthenticationFormTestCase(SimpleTestCase):
     """
     Tests that the AuthenticationForm manages valid/invalid
     credentials and problems with the api.
+
+    Mocks the `authenticate` method so that we can use it
+    everywhere in our test methods.
     """
 
-    @mock.patch('mtp_auth.forms.authenticate')
-    def __call__(self, result, mocked_authenticate, *args, **kwargs):
-        """
-        Mocks the `authenticate` method so that we can use it
-        everywhere in our test methods.
-        """
-        self.mocked_authenticate = mocked_authenticate
-        super(AuthenticationFormTest, self).__call__(result, *args, **kwargs)
-
     def setUp(self):
-        super(AuthenticationFormTest, self).setUp()
+        super(AuthenticationFormTestCase, self).setUp()
         self.credentials = {
             'username': 'testclient',
             'password': 'password',
         }
 
-    def test_invalid_credentials(self):
+    def test_invalid_credentials(self, mocked_authenticate):
         """
         The User submits invalid credentials
         """
-        self.mocked_authenticate.return_value = None
+        mocked_authenticate.return_value = None
 
         data = {
             'username': 'jsmith_does_not_exist',
@@ -48,29 +42,16 @@ class AuthenticationFormTest(SimpleTestCase):
             [force_text(form.error_messages['invalid_login'])]
         )
 
-        self.mocked_authenticate.assert_called_with(**data)
+        mocked_authenticate.assert_called_with(**data)
 
-    def test_success(self):
+    def test_success(self, mocked_authenticate):
         """
         Successful authentication.
         """
-        self.mocked_authenticate.return_value = mock.MagicMock()
+        mocked_authenticate.return_value = mock.MagicMock()
 
         form = AuthenticationForm(data=self.credentials)
         self.assertTrue(form.is_valid())
         self.assertEqual(form.non_field_errors(), [])
 
-        self.mocked_authenticate.assert_called_with(**self.credentials)
-
-    def test_api_connection_error(self):
-        """
-        The app cannot connect to the api server.
-        """
-        self.mocked_authenticate.side_effect = ConnectionError()
-
-        form = AuthenticationForm(data=self.credentials)
-        self.assertFalse(form.is_valid())
-        self.assertEqual(
-            form.non_field_errors(),
-            [force_text(form.error_messages['connection_error'])]
-        )
+        mocked_authenticate.assert_called_with(**self.credentials)

--- a/mtp_cashbook/apps/mtp_auth/tests/utils.py
+++ b/mtp_cashbook/apps/mtp_auth/tests/utils.py
@@ -1,0 +1,15 @@
+from django.utils.crypto import get_random_string
+
+
+def generate_tokens(**kwargs):
+    """
+    Returns a dict with random access_token and refresh_token.
+    Whatever is passed via kwargs will be added or replace
+    dict values.
+    """
+    defaults = {
+        'access_token': get_random_string(length=30),
+        'refresh_token': get_random_string(length=30)
+    }
+    defaults.update(kwargs)
+    return defaults

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -144,6 +144,7 @@ API_URL = os.environ.get('API_URL', 'http://localhost:8000')
 LOGIN_URL = 'auth:login'
 LOGIN_REDIRECT_URL = 'index'
 
+OAUTHLIB_INSECURE_TRANSPORT = True
 
 try:
     from .local import *

--- a/mtp_cashbook/settings/prod.py
+++ b/mtp_cashbook/settings/prod.py
@@ -19,3 +19,6 @@ ALLOWED_HOSTS = [
     '.dsd.io',
     '.service.gov.uk'
 ]
+
+# make sure that we are using secure transport during oauth2
+OAUTHLIB_INSECURE_TRANSPORT = False

--- a/mtp_cashbook/settings/prod.py
+++ b/mtp_cashbook/settings/prod.py
@@ -12,7 +12,7 @@ from mtp_cashbook.settings.base import *
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = os.environ.get('DEBUG', False)
 
 ALLOWED_HOSTS = [
     'localhost',
@@ -20,5 +20,6 @@ ALLOWED_HOSTS = [
     '.service.gov.uk'
 ]
 
-# make sure that we are using secure transport during oauth2
-OAUTHLIB_INSECURE_TRANSPORT = False
+OAUTHLIB_INSECURE_TRANSPORT = os.environ.get(
+    'OAUTHLIB_INSECURE_TRANSPORT', False
+)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 # Place your base dependencies here
 Django==1.8.2
 slumber==0.7.1
+requests-oauthlib==0.5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
 # Place your development dependencies here
 -r base.txt
 mock==1.0.1
+responses==0.4.0


### PR DESCRIPTION
This changes the way the code calls the api simplifying its logic.
Only 2 functions are exposed:
- `api_client.authenticate` which authenticates against the api
- `api_client.get_connection` which returns a slumber connection able
to deal with refreshing the access token automatically if needed.

In this way, the views can just use the connection without worrying about
tokens at all.