### PR TITLE
Add request to context processors

### DIFF
--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -123,6 +123,7 @@ LOGGING = {
 
 TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
     'mtp_cashbook.apps.core.context_processors.debug',
+    'django.core.context_processors.request'
 )
 
 DATABASES = {}


### PR DESCRIPTION
This is so that we can use the request object in our django templates
(e.g. request.user.username)