### PR TITLE
Stop docker-compose building our image twice

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,13 @@ django:
     API_URL:
 
 djangogulpserve:
-  build: .
-  command: /bin/bash -c "npm install --unsafe-perm && gulp serve --host=$DJANGO_1_PORT_8001_TCP_ADDR --port=$TESTMOJDJANGO_DJANGO_1_PORT_8001_TCP_PORT"
+  image: moneytoprisonerscashbook_django
+  command: >
+    /bin/bash -c "
+      npm install --unsafe-perm &&
+      gulp serve --host=$DJANGO_1_PORT_8001_TCP_ADDR \
+                 --port=$DJANGO_1_PORT_8001_TCP_PORT
+    "
   volumes:
     - .:/app
     - /tmp/npm/:/root/.npm/


### PR DESCRIPTION
The djangogulpserve container uses the same image as the django container, so we should explicitly indicate that's what we want to avoid building it twice. If djangogulpserve needed to be run on its own
this would break, but we never actually need that because it only exists for serving assets during development.

Also make the the environment variable passed to `--port` consistent with the one used for `--host`.