### PR TITLE
Automate the getting started process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ node_modules
 
 mtp_cashbook/assets-src/bower_components
 mtp_cashbook/assets/
+
+# Docker make targets
+.dev_django_container

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ endif
 
 endif
 
-.dev_django_container: $(boot2docker_up) $(boot2docker_shellinit) .
+.dev_django_container: $(boot2docker_up) $(boot2docker_shellinit) \
+  Dockerfile docker-compose.yml \
+  requirements/base.txt requirements/prod.txt
 	docker-compose build
 	@docker inspect -f '{{.Id}}' moneytoprisonerscashbook_django > .dev_django_container
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ RESET=\033[0m
 err=echo "$(ERROR)$(1)$(RESET)"
 warn=echo "$(WARNING)$(1)$(RESET)"
 
+all: test run
+
+test: build
+	$(API_ENDPOINT) docker-compose run django bash -c \
+	    "pip install --quiet -r requirements/dev.txt && \
+	     /app/manage.py test"
+
 run: build
 	$(API_ENDPOINT) docker-compose up
 
@@ -41,4 +48,4 @@ clean:
 	docker-compose stop
 	docker-compose rm -f
 
-.PHONY: run build boot2docker_up boot2docker_shellinit clean
+.PHONY: all test run build boot2docker_up boot2docker_shellinit clean

--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,11 @@ boot2docker_shellinit: $(boot2docker_up)
 	@$(call warn,Run this to avoid doing setting them every time:)
 	@$(call warn,$$ eval "\$$\(boot2docker shellinit\)")
 	$(foreach line, $(shell boot2docker shellinit), $(eval $(line)))
-else
-# Always ensure we have a VM
-boot2docker_shellinit=boot2docker_up
 endif
 
 endif
 
-.dev_django_container: $(boot2docker_shellinit) .
+.dev_django_container: $(boot2docker_up) $(boot2docker_shellinit) .
 	docker-compose build
 	@docker inspect -f '{{.Id}}' moneytoprisonerscashbook_django > .dev_django_container
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: test run
 test: build
 	$(API_ENDPOINT) docker-compose run django bash -c \
 	    "pip install --quiet -r requirements/dev.txt && \
-	     /app/manage.py test"
+	     /app/manage.py test $(TEST)"
 
 run: build
 	$(API_ENDPOINT) docker-compose up

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+ifneq ($(shell command -v boot2docker),)
+API_ENDPOINT=API_URL=http://`boot2docker ip`:8000
+endif
+
+run: build
+	$(API_ENDPOINT) docker-compose up
+
+build: .dev_django_container
+
+.dev_django_container: .
+	docker-compose build
+	@docker inspect -f '{{.Id}}' moneytoprisonerscashbook_django > .dev_django_container
+
+clean:
+	@rm -f .dev_django_container
+	docker-compose stop
+	docker-compose rm -f
+
+.PHONY: run build clean

--- a/Makefile
+++ b/Makefile
@@ -17,26 +17,25 @@ run: build
 build: .dev_django_container
 
 ifneq ($(shell command -v boot2docker),)
-API_ENDPOINT=API_URL=http://`boot2docker ip`:8000
+  API_ENDPOINT=API_URL=http://`boot2docker ip`:8000
 
-b2d_status=$(shell boot2docker status)
+  b2d_status=$(shell boot2docker status)
 
-ifneq ($(b2d_status),running)
-boot2docker_up=boot2docker_up
-boot2docker_up:
-	boot2docker init
-	boot2docker up
-endif
+  ifneq ($(b2d_status),running)
+    boot2docker_up=boot2docker_up
+    boot2docker_up:
+	    boot2docker init
+	    boot2docker up
+  endif
 
-ifndef DOCKER_HOST
-boot2docker_shellinit=boot2docker_shellinit
-boot2docker_shellinit: $(boot2docker_up)
-	@$(call warn,Setting boot2docker environment variables)
-	@$(call warn,Run this to avoid doing setting them every time:)
-	@$(call warn,$$ eval "\$$\(boot2docker shellinit\)")
-	$(foreach line, $(shell boot2docker shellinit), $(eval $(line)))
-endif
-
+  ifndef DOCKER_HOST
+    boot2docker_shellinit=boot2docker_shellinit
+    boot2docker_shellinit: $(boot2docker_up)
+	    @$(call warn,Setting boot2docker environment variables)
+	    @$(call warn,Run this to avoid doing setting them every time:)
+	    @$(call warn,$$ eval "\$$\(boot2docker shellinit\)")
+	    $(foreach line, $(shell boot2docker shellinit), $(eval $(line)))
+  endif
 endif
 
 .dev_django_container: $(boot2docker_up) $(boot2docker_shellinit) \

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ ifneq ($(shell command -v boot2docker),)
   endif
 endif
 
-.dev_django_container: $(boot2docker_up) $(boot2docker_shellinit) \
-  Dockerfile docker-compose.yml \
-  requirements/base.txt requirements/prod.txt
+.dev_django_container: Dockerfile docker-compose.yml \
+  requirements/base.txt requirements/prod.txt \
+  | $(boot2docker_up) $(boot2docker_shellinit)
 	docker-compose build
 	@docker inspect -f '{{.Id}}' moneytoprisonerscashbook_django > .dev_django_container
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ and if you're planning to deploy then you'll need the [deployment
 repository](https://github.com/ministryofjustice/money-to-prisoners-deploy)
 (private repository).
 
+## Run the tests
+
+In a terminal `cd` into the directory you checked this project out into, then
+
+```
+$ make test
+```
+
 ## Development Server
 
 In a terminal `cd` into the directory you checked this project out into, then

--- a/README.md
+++ b/README.md
@@ -29,15 +29,9 @@ and if you're planning to deploy then you'll need the [deployment repository](ht
 > ```
 
 In a terminal `cd` into the directory you checked this project out into, then
-```
-$ docker-compose build && docker-compose up
-```
-
-If running under boot2docker, be sure to pass the `API_URL` to
-`docker-compose` when starting the containers:
 
 ```
-$ docker-compose build && API_URL=http://`boot2docker ip`:8000 docker-compose up
+$ make run
 ```
 
 Wait while Docker does it's stuff and you'll soon see something like:

--- a/README.md
+++ b/README.md
@@ -3,30 +3,19 @@ The Cashbook UI for the Money to Prisoners Project
 
 ## Dependencies
 ### Docker
-To run this project locally you need to have 
-[Docker](http://docs.docker.com/installation/mac/) and 
+To run this project locally you need to have
+[Docker](http://docs.docker.com/installation/mac/) and
 [Docker Compose](https://docs.docker.com/compose/install/) installed.
 
 ### Other Repositories
-Alongside this repository you'll need the [API server](https://github.com/ministryofjustice/money-to-prisoners-api)
-and if you're planning to deploy then you'll need the [deployment repository](https://github.com/ministryofjustice/money-to-prisoners-deploy) (private repository)
+
+Alongside this repository you'll need the [API
+server](https://github.com/ministryofjustice/money-to-prisoners-api)
+and if you're planning to deploy then you'll need the [deployment
+repository](https://github.com/ministryofjustice/money-to-prisoners-deploy)
+(private repository).
 
 ## Development Server
-### Boot2Docker
-> If you're developing on a Mac then Docker won't run natively, you'll be 
-> running a single virtual machine with linux installed where your Docker 
-> containers run. The first time you will need to create the virtual machine.
->
-> ```
-> $ boot2docker init
-> ```
->
-> Run the virtual machine:
->
-> ```
-> $ boot2docker up
-> $ eval "$(boot2docker shellinit)"
-> ```
 
 In a terminal `cd` into the directory you checked this project out into, then
 
@@ -40,10 +29,11 @@ djangogulpserve_1 | [BS] Now you can access your site through the following addr
 djangogulpserve_1 | [BS] Local URL: http://localhost:3000
 ```
 
-you should be able to point your browser at
-[http://localhost:3000](http://localhost:3000)
-if you're using *boot2docker* then it'll be at the IP of the boot2docker virtual machine.
-You can find it by typing `boot2docker ip` in a terminal. Then visit http://**boot2docker ip**:3000/
+You should be able to point your browser at
+[http://localhost:3000](http://localhost:3000) if you're using
+*boot2docker* then it'll be at the IP of the boot2docker virtual
+machine. You can find it by typing `boot2docker ip` in a terminal. Then
+visit http://**boot2docker ip**:3000/
 
 ## Login
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ In a terminal `cd` into the directory you checked this project out into, then
 $ make test
 ```
 
+To run a specific test, or set of tests, run:
+
+```
+$ make test TEST=[testname]
+```
+
 ## Development Server
 
 In a terminal `cd` into the directory you checked this project out into, then


### PR DESCRIPTION
There are a handful of complex, conditional steps people have to jump through before being able to work with our codebase. This attempts to automate them all using `make`, including starting `boot2docker` (if it's installed; otherwise we assume it's unnecessary), and means we can simplify the process of working with our code.