### PR TITLE
Improve Docker caching of JavaScript dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,10 @@ ADD ./conf/uwsgi /etc/uwsgi
 ADD ./requirements/ /app/requirements/
 RUN pip3 install -r requirements/prod.txt
 
-ADD . /app
-
+ADD .bowerrc bower.json package.json README.md /app/
 RUN npm install --unsafe-perm
+
+ADD . /app
 RUN gulp
 RUN ./manage.py collectstatic --noinput
 


### PR DESCRIPTION
`ADD`ing the project directory before `npm install` meant that any change, anywhere in the project directory, would invalidate the Docker build cache for the `npm install` step. Given that this step involves a number of network requests, and installs npm and bower packages, it ends up being very slow.

Explicitly `ADD`ing bower/npm package config (and the README, which is apparently used for the npm package description) means Docker only invalidates the cache (and, thus, re-runs the `npm install`) when these files change. This dramatically improves rebuild times (from ~2m30 to <10s) for the majority of changes.