### PR TITLE
Add linting helper and fix existing linting issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ node_modules
 
 mtp_cashbook/assets-src/bower_components
 mtp_cashbook/assets/
+
+# Docker make targets
+.dev_django_container

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ endif
 
 endif
 
-.dev_django_container: $(boot2docker_up) $(boot2docker_shellinit) .
+.dev_django_container: $(boot2docker_up) $(boot2docker_shellinit) \
+  Dockerfile docker-compose.yml \
+  requirements/base.txt requirements/prod.txt
 	docker-compose build
 	@docker inspect -f '{{.Id}}' moneytoprisonerscashbook_django > .dev_django_container
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ RESET=\033[0m
 err=echo "$(ERROR)$(1)$(RESET)"
 warn=echo "$(WARNING)$(1)$(RESET)"
 
+all: test run
+
+test: build
+	$(API_ENDPOINT) docker-compose run django bash -c \
+	    "pip install --quiet -r requirements/dev.txt && \
+	     /app/manage.py test"
+
 run: build
 	$(API_ENDPOINT) docker-compose up
 
@@ -41,4 +48,4 @@ clean:
 	docker-compose stop
 	docker-compose rm -f
 
-.PHONY: run build boot2docker_up boot2docker_shellinit clean
+.PHONY: all test run build boot2docker_up boot2docker_shellinit clean

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: lint test run
 lint: build
 	docker-compose run django bash -c \
 	    "pip install --quiet -r requirements/dev.txt && \
-	     flake8 ."
+	     flake8 $(LINT_OPTS) ."
 
 test: build
 	$(API_ENDPOINT) docker-compose run django bash -c \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,12 @@ RESET=\033[0m
 err=echo "$(ERROR)$(1)$(RESET)"
 warn=echo "$(WARNING)$(1)$(RESET)"
 
-all: test run
+all: lint test run
+
+lint: build
+	docker-compose run django bash -c \
+	    "pip install --quiet -r requirements/dev.txt && \
+	     flake8 ."
 
 test: build
 	$(API_ENDPOINT) docker-compose run django bash -c \
@@ -50,4 +55,4 @@ clean:
 	docker-compose stop
 	docker-compose rm -f
 
-.PHONY: all test run build boot2docker_up boot2docker_shellinit clean
+.PHONY: all lint test run build boot2docker_up boot2docker_shellinit clean

--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,11 @@ boot2docker_shellinit: $(boot2docker_up)
 	@$(call warn,Run this to avoid doing setting them every time:)
 	@$(call warn,$$ eval "\$$\(boot2docker shellinit\)")
 	$(foreach line, $(shell boot2docker shellinit), $(eval $(line)))
-else
-# Always ensure we have a VM
-boot2docker_shellinit=boot2docker_up
 endif
 
 endif
 
-.dev_django_container: $(boot2docker_shellinit) .
+.dev_django_container: $(boot2docker_up) $(boot2docker_shellinit) .
 	docker-compose build
 	@docker inspect -f '{{.Id}}' moneytoprisonerscashbook_django > .dev_django_container
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: test run
 test: build
 	$(API_ENDPOINT) docker-compose run django bash -c \
 	    "pip install --quiet -r requirements/dev.txt && \
-	     /app/manage.py test"
+	     /app/manage.py test $(TEST)"
 
 run: build
 	$(API_ENDPOINT) docker-compose up

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+ifneq ($(shell command -v boot2docker),)
+API_ENDPOINT=API_URL=http://`boot2docker ip`:8000
+endif
+
+run: build
+	$(API_ENDPOINT) docker-compose up
+
+build: .dev_django_container
+
+.dev_django_container: .
+	docker-compose build
+	@docker inspect -f '{{.Id}}' moneytoprisonerscashbook_django > .dev_django_container
+
+clean:
+	@rm -f .dev_django_container
+	docker-compose stop
+	docker-compose rm -f
+
+.PHONY: run build clean

--- a/README.md
+++ b/README.md
@@ -3,30 +3,19 @@ The Cashbook UI for the Money to Prisoners Project
 
 ## Dependencies
 ### Docker
-To run this project locally you need to have 
-[Docker](http://docs.docker.com/installation/mac/) and 
+To run this project locally you need to have
+[Docker](http://docs.docker.com/installation/mac/)and
 [Docker Compose](https://docs.docker.com/compose/install/) installed.
 
 ### Other Repositories
-Alongside this repository you'll need the [API server](https://github.com/ministryofjustice/money-to-prisoners-api)
-and if you're planning to deploy then you'll need the [deployment repository](https://github.com/ministryofjustice/money-to-prisoners-deploy) (private repository)
+
+Alongside this repository you'll need the [API
+server](https://github.com/ministryofjustice/money-to-prisoners-api)
+and if you're planning to deploy then you'll need the [deployment
+repository](https://github.com/ministryofjustice/money-to-prisoners-deploy)
+(private repository).
 
 ## Development Server
-### Boot2Docker
-> If you're developing on a Mac then Docker won't run natively, you'll be 
-> running a single virtual machine with linux installed where your Docker 
-> containers run. The first time you will need to create the virtual machine.
->
-> ```
-> $ boot2docker init
-> ```
->
-> Run the virtual machine:
->
-> ```
-> $ boot2docker up
-> $ eval "$(boot2docker shellinit)"
-> ```
 
 In a terminal `cd` into the directory you checked this project out into, then
 
@@ -40,10 +29,11 @@ djangogulpserve_1 | [BS] Now you can access your site through the following addr
 djangogulpserve_1 | [BS] Local URL: http://localhost:3000
 ```
 
-you should be able to point your browser at
-[http://localhost:3000](http://localhost:3000)
-if you're using *boot2docker* then it'll be at the IP of the boot2docker virtual machine.
-You can find it by typing `boot2docker ip` in a terminal. Then visit http://**boot2docker ip**:3000/
+You should be able to point your browser at
+[http://localhost:3000](http://localhost:3000) if you're using
+*boot2docker* then it'll be at the IP of the boot2docker virtual
+machine. You can find it by typing `boot2docker ip` in a terminal. Then
+visit http://**boot2docker ip**:3000/
 
 ## Login
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ and if you're planning to deploy then you'll need the [deployment
 repository](https://github.com/ministryofjustice/money-to-prisoners-deploy)
 (private repository).
 
+## Run the tests
+
+In a terminal `cd` into the directory you checked this project out into, then
+
+```
+$ make test
+```
+
 ## Development Server
 
 In a terminal `cd` into the directory you checked this project out into, then

--- a/README.md
+++ b/README.md
@@ -29,15 +29,9 @@ and if you're planning to deploy then you'll need the [deployment repository](ht
 > ```
 
 In a terminal `cd` into the directory you checked this project out into, then
-```
-$ docker-compose build && docker-compose up
-```
-
-If running under boot2docker, be sure to pass the `API_URL` to
-`docker-compose` when starting the containers:
 
 ```
-$ docker-compose build && API_URL=http://`boot2docker ip`:8000 docker-compose up
+$ make run
 ```
 
 Wait while Docker does it's stuff and you'll soon see something like:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ In a terminal `cd` into the directory you checked this project out into, then
 $ make test
 ```
 
+To run a specific test, or set of tests, run:
+
+```
+$ make test TEST=[testname]
+```
+
 ## Development Server
 
 In a terminal `cd` into the directory you checked this project out into, then

--- a/mtp_cashbook/apps/core/models.py
+++ b/mtp_cashbook/apps/core/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/mtp_cashbook/apps/core/views.py
+++ b/mtp_cashbook/apps/core/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/mtp_cashbook/apps/mtp_auth/forms.py
+++ b/mtp_cashbook/apps/mtp_auth/forms.py
@@ -14,7 +14,8 @@ class AuthenticationForm(forms.Form):
     error_messages = {
         'invalid_login': _("Please enter a correct username and password. "
                            "Note that both fields may be case-sensitive."),
-        'connection_error': _("The API Server seems down, please try again later."),
+        'connection_error': _("The API Server seems down, "
+                              "please try again later."),
     }
 
     def __init__(self, request=None, *args, **kwargs):

--- a/mtp_cashbook/apps/mtp_auth/forms.py
+++ b/mtp_cashbook/apps/mtp_auth/forms.py
@@ -41,9 +41,9 @@ class AuthenticationForm(forms.Form):
             except ConnectionError:
                 # in case of problems connecting to the api server
                 raise forms.ValidationError(
-                        self.error_messages['connection_error'],
-                        code='connection_error',
-                    )
+                    self.error_messages['connection_error'],
+                    code='connection_error',
+                )
 
         return self.cleaned_data
 

--- a/mtp_cashbook/apps/mtp_auth/tests/test_api_client.py
+++ b/mtp_cashbook/apps/mtp_auth/tests/test_api_client.py
@@ -157,8 +157,8 @@ class GetConnectionTestCase(SimpleTestCase):
         now = datetime.datetime.now()
         one_day_delta = datetime.timedelta(days=1)
 
-        expired_yesterday = build_expires_at(now-one_day_delta)
-        expires_tomorrow = build_expires_at(now+one_day_delta)
+        expired_yesterday = build_expires_at(now - one_day_delta)
+        expires_tomorrow = build_expires_at(now + one_day_delta)
 
         # set access_token.expires_at to yesterday
         self.request.user.token['expires_at'] = expired_yesterday

--- a/mtp_cashbook/apps/mtp_auth/tests/test_views.py
+++ b/mtp_cashbook/apps/mtp_auth/tests/test_views.py
@@ -69,7 +69,8 @@ class LoginViewTestCase(SimpleTestCase):
         # logout
         response = self.client.post(self.logout_url, follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(self.client.session.items()), 0)  # nothing in the session
+        # nothing in the session
+        self.assertEqual(len(self.client.session.items()), 0)
 
     def test_invalid_credentials(self, mocked_api_client):
         """
@@ -91,4 +92,5 @@ class LoginViewTestCase(SimpleTestCase):
             form.errors['__all__'],
             [force_text(form.error_messages['invalid_login'])]
         )
-        self.assertEqual(len(self.client.session.items()), 0)  # nothing in the session
+        # nothing in the session
+        self.assertEqual(len(self.client.session.items()), 0)

--- a/mtp_cashbook/apps/mtp_auth/urls.py
+++ b/mtp_cashbook/apps/mtp_auth/urls.py
@@ -2,9 +2,12 @@ from django.conf.urls import patterns, url
 from django.core.urlresolvers import reverse_lazy
 
 
-urlpatterns = patterns('',
+urlpatterns = patterns(
+    '',
     url(r'^login/$', 'mtp_auth.views.login', name='login'),
-    url(r'^logout/$', 'mtp_auth.views.logout', {
+    url(
+        r'^logout/$', 'mtp_auth.views.logout',
+        {
             'next_page': reverse_lazy('auth:login')
         }, name='logout'
     ),

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -20,7 +20,9 @@ from django.conf import global_settings
 here = lambda *x: join(abspath(dirname(__file__)), *x)
 PROJECT_ROOT = here("..")
 root = lambda *x: join(abspath(PROJECT_ROOT), *x)
-bower_dir = lambda *x: join(json.load(open(root('..', '.bowerrc')))['directory'], *x)
+bower_dir = lambda *x: join(
+    json.load(open(root('..', '.bowerrc')))['directory'], *x
+)
 
 sys.path.insert(0, os.path.join(root(), 'apps'))
 
@@ -101,7 +103,8 @@ LOGGING = {
     'disable_existing_loggers': False,
     'formatters': {
         'verbose': {
-            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
+            'format': '%(levelname)s %(asctime)s %(module)s '
+                      '%(process)d %(thread)d %(message)s'
         },
         'simple': {
             'format': '%(levelname)s %(message)s'

--- a/mtp_cashbook/urls.py
+++ b/mtp_cashbook/urls.py
@@ -2,13 +2,14 @@ from django.conf.urls import patterns, include, url
 from django.contrib.auth.decorators import login_required
 from django.views.generic.base import TemplateView
 
-urlpatterns = patterns('',
-    # Examples:
-    # url(r'^$', 'mtp_cashbook.views.home', name='home'),
-    # url(r'^blog/', include('blog.urls')),
-    url(r'^$', login_required(
+urlpatterns = patterns(
+    '',
+    url(
+        r'^$',
+        login_required(
             TemplateView.as_view(template_name='core/index.html')
-        ), name='index'
+        ),
+        name='index'
     ),
 
     url(r'^auth/', include('mtp_auth.urls', namespace='auth',)),

--- a/mtp_cashbook/wsgi.py
+++ b/mtp_cashbook/wsgi.py
@@ -13,4 +13,3 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mtp_cashbook.settings.prod")
 from django.core.wsgi import get_wsgi_application
 
 application = get_wsgi_application()
-

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,3 +2,4 @@
 -r base.txt
 mock==1.0.1
 responses==0.4.0
+flake8==2.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-complexity = 10
+exclude = node_modules/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [flake8]
+
+ignore = F403
 max-complexity = 10
 exclude = node_modules/*


### PR DESCRIPTION
We need an easy way of checking that our code matches [pep8](https://www.python.org/dev/peps/pep-0008/) (Python's style guide). This adds `make lint` for that purpose.

Also fixes linting errors in the current codebase.

It's possibly worth reviewing this one commit at a time. Once it's merged to master, I'll look at linting in Jenkins.