### PR TITLE
Add linting helper and fix existing linting issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: lint test run
 lint: build
 	docker-compose run django bash -c \
 	    "pip install --quiet -r requirements/dev.txt && \
-	     flake8 ."
+	     flake8 $(LINT_OPTS) ."
 
 test: build
 	$(API_ENDPOINT) docker-compose run django bash -c \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,16 @@ all: lint test run
 lint: build
 	docker-compose run django bash -c \
 	    "pip install --quiet -r requirements/dev.txt && \
-	     flake8 $(LINT_OPTS) ."
+	     flake8 $(LINT_OPTS) . && \
+	     find . \( -path ./node_modules -o \
+	               -path ./mtp_cashbook/assets-src/bower_components -o \
+	               -path ./requirements \
+	            \) \
+	            -prune -o \( \
+	               -name '*.html' -or \
+	               -name '*.txt' \
+	            \) -print | \
+	     xargs django-template-i18n-lint"
 
 test: build
 	$(API_ENDPOINT) docker-compose run django bash -c \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,12 @@ RESET=\033[0m
 err=echo "$(ERROR)$(1)$(RESET)"
 warn=echo "$(WARNING)$(1)$(RESET)"
 
-all: test run
+all: lint test run
+
+lint: build
+	docker-compose run django bash -c \
+	    "pip install --quiet -r requirements/dev.txt && \
+	     flake8 ."
 
 test: build
 	$(API_ENDPOINT) docker-compose run django bash -c \
@@ -49,4 +54,4 @@ clean:
 	docker-compose stop
 	docker-compose rm -f
 
-.PHONY: all test run build boot2docker_up boot2docker_shellinit clean
+.PHONY: all lint test run build boot2docker_up boot2docker_shellinit clean

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ In a terminal `cd` into the directory you checked this project out into, then:
 $ make lint
 ```
 
+To check for a [specific class of style
+violation](http://flake8.readthedocs.org/en/latest/warnings.html), run:
+
+```
+$ make lint LINT_OPTS="--select [lint-rules]"
+```
+
 ### Run a development Server
 
 In a terminal `cd` into the directory you checked this project out into, then

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ and if you're planning to deploy then you'll need the [deployment
 repository](https://github.com/ministryofjustice/money-to-prisoners-deploy)
 (private repository).
 
-## Run the tests
+## Working with the code
 
-In a terminal `cd` into the directory you checked this project out into, then
+### Run the tests
+
+In a terminal `cd` into the directory you checked this project out into, then:
 
 ```
 $ make test
@@ -29,7 +31,15 @@ To run a specific test, or set of tests, run:
 $ make test TEST=[testname]
 ```
 
-## Development Server
+### Validate code style
+
+In a terminal `cd` into the directory you checked this project out into, then:
+
+```
+$ make lint
+```
+
+### Run a development Server
 
 In a terminal `cd` into the directory you checked this project out into, then
 
@@ -49,7 +59,7 @@ You should be able to point your browser at
 machine. You can find it by typing `boot2docker ip` in a terminal. Then
 visit http://**boot2docker ip**:3000/
 
-## Login
+### Log in to the application
 
 Make sure you have a version of the [API](https://github.com/ministryofjustice/money-to-prisoners-api) server
 running on port 8000.

--- a/mtp_cashbook/apps/cashbook/admin.py
+++ b/mtp_cashbook/apps/cashbook/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/mtp_cashbook/apps/cashbook/forms.py
+++ b/mtp_cashbook/apps/cashbook/forms.py
@@ -43,7 +43,7 @@ class ProcessTransactionBatchForm(forms.Form):
         transactions = resp.get('results', [])
 
         return [
-           (t['id'], t) for t in transactions
+            (t['id'], t) for t in transactions
         ]
 
     def save(self):

--- a/mtp_cashbook/apps/cashbook/models.py
+++ b/mtp_cashbook/apps/cashbook/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/mtp_cashbook/apps/cashbook/templatetags/currency.py
+++ b/mtp_cashbook/apps/cashbook/templatetags/currency.py
@@ -2,6 +2,7 @@ from django import template
 
 register = template.Library()
 
+
 @register.filter(is_safe=True)
 def currency(value):
     return '{:.2f}'.format(value / 100.)

--- a/mtp_cashbook/apps/cashbook/templatetags/currency.py
+++ b/mtp_cashbook/apps/cashbook/templatetags/currency.py
@@ -4,4 +4,4 @@ register = template.Library()
 
 @register.filter(is_safe=True)
 def currency(value):
-    return '{:.2f}'.format(value/100.)
+    return '{:.2f}'.format(value / 100.)

--- a/mtp_cashbook/apps/core/models.py
+++ b/mtp_cashbook/apps/core/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/mtp_cashbook/apps/core/views.py
+++ b/mtp_cashbook/apps/core/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/mtp_cashbook/apps/mtp_auth/forms.py
+++ b/mtp_cashbook/apps/mtp_auth/forms.py
@@ -41,9 +41,9 @@ class AuthenticationForm(forms.Form):
             except ConnectionError:
                 # in case of problems connecting to the api server
                 raise forms.ValidationError(
-                        self.error_messages['connection_error'],
-                        code='connection_error',
-                    )
+                    self.error_messages['connection_error'],
+                    code='connection_error',
+                )
 
         return self.cleaned_data
 

--- a/mtp_cashbook/apps/mtp_auth/tests/test_api_client.py
+++ b/mtp_cashbook/apps/mtp_auth/tests/test_api_client.py
@@ -157,8 +157,8 @@ class GetConnectionTestCase(SimpleTestCase):
         now = datetime.datetime.now()
         one_day_delta = datetime.timedelta(days=1)
 
-        expired_yesterday = build_expires_at(now-one_day_delta)
-        expires_tomorrow = build_expires_at(now+one_day_delta)
+        expired_yesterday = build_expires_at(now - one_day_delta)
+        expires_tomorrow = build_expires_at(now + one_day_delta)
 
         # set access_token.expires_at to yesterday
         self.request.user.token['expires_at'] = expired_yesterday

--- a/mtp_cashbook/apps/mtp_auth/urls.py
+++ b/mtp_cashbook/apps/mtp_auth/urls.py
@@ -4,7 +4,8 @@ from django.core.urlresolvers import reverse_lazy
 
 urlpatterns = patterns('',
     url(r'^login/$', 'mtp_auth.views.login', name='login'),
-    url(r'^logout/$', 'mtp_auth.views.logout', {
+    url(
+        r'^logout/$', 'mtp_auth.views.logout', {
             'next_page': reverse_lazy('auth:login')
         }, name='logout'
     ),

--- a/mtp_cashbook/settings/__init__.py
+++ b/mtp_cashbook/settings/__init__.py
@@ -1,1 +1,1 @@
-from .base import *
+from .base import *  # noqa

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -161,6 +161,6 @@ LOGIN_REDIRECT_URL = 'dashboard'
 OAUTHLIB_INSECURE_TRANSPORT = True
 
 try:
-    from .local import *
+    from .local import *  # noqa
 except ImportError:
     pass

--- a/mtp_cashbook/settings/prod.py
+++ b/mtp_cashbook/settings/prod.py
@@ -6,7 +6,7 @@ See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
 import os
 
 
-from mtp_cashbook.settings.base import *
+from mtp_cashbook.settings.base import *  # noqa
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')

--- a/mtp_cashbook/wsgi.py
+++ b/mtp_cashbook/wsgi.py
@@ -13,4 +13,3 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mtp_cashbook.settings.prod")
 from django.core.wsgi import get_wsgi_application
 
 application = get_wsgi_application()
-

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,3 +2,4 @@
 -r base.txt
 mock==1.0.1
 responses==0.4.0
+flake8==2.4.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,3 +4,4 @@ mock==1.0.1
 responses==0.4.0
 flake8==2.4.1
 pep8-naming==0.3.3
+django-template-i18n-lint==1.2.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,3 +3,4 @@
 mock==1.0.1
 responses==0.4.0
 flake8==2.4.1
+pep8-naming==0.3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-complexity = 10
+exclude = node_modules/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [flake8]
-max-complexity = 10
 exclude = node_modules/*
+ignore = E128
+max-complexity = 10
+max-line-length = 119


### PR DESCRIPTION
We need an easy way of checking that our code matches [pep8](https://www.python.org/dev/peps/pep-0008/) (Python's style guide). This adds `make lint` for that purpose, and fixes existing linting errors.

It's probably worth reviewing this one commit at a time. Once it's merged to master, I'll look at linting in Jenkins.