### PR TITLE
Make container builds rely on JS dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ ifneq ($(shell command -v boot2docker),)
 endif
 
 .dev_django_container: Dockerfile docker-compose.yml \
+  .bowerrc bower.json package.json README.md \
   requirements/base.txt requirements/prod.txt \
   | $(boot2docker_up) $(boot2docker_shellinit)
 	docker-compose build


### PR DESCRIPTION
If we change our JavaScript dependencies, we should rebuild the container.