### PR TITLE
Fix invalid character error in Sass

### DIFF
--- a/mtp_cashbook/assets-src/stylesheets/app.scss
+++ b/mtp_cashbook/assets-src/stylesheets/app.scss
@@ -1,3 +1,5 @@
+@charset 'UTF-8';
+
 $images-dir: '/static/images/';
 
 @import 'govuk';


### PR DESCRIPTION
Currently getting an 'Invalid US-ASCII character "\xE2"' error in the compiled CSS file