### PR TITLE
Install en_US.UTF-8 locale to fix assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:trusty
 
+RUN locale-gen "en_US.UTF-8"
+ENV LC_CTYPE=en_US.UTF-8
+
 RUN apt-get update && \
     apt-get install -y software-properties-common python-software-properties
 


### PR DESCRIPTION
See 6fcc62845dcbb43d3b90bcbf10721f6213da3716. This also installs the UTF
locale on the box and sets it in the LC_CTYPE env var as suggested here
https://github.com/sindresorhus/gulp-ruby-sass/issues/232