### PR TITLE
Namespace cashbook transactions

### DIFF
--- a/mtp_cashbook/apps/cashbook/forms.py
+++ b/mtp_cashbook/apps/cashbook/forms.py
@@ -15,10 +15,10 @@ class ProcessTransactionBatchForm(forms.Form):
         self.fields['transactions'].choices = self.transaction_choices
 
     def _request_pending_transactions(self):
-        return self.client.transactions(self.user.prison)(self.user.pk).get(status='pending')
+        return self.client.cashbook().transactions(self.user.prison)(self.user.pk).get(status='pending')
 
     def _take_transactions(self):
-        self.client.transactions(self.user.prison)(self.user.pk).take.post()
+        self.client.cashbook().transactions(self.user.prison)(self.user.pk).take.post()
 
     def clean_transactions(self):
         """
@@ -58,13 +58,13 @@ class ProcessTransactionBatchForm(forms.Form):
 
         # credit
         if to_credit:
-            self.client.transactions(self.user.prison)(self.user.pk).patch(
+            self.client.cashbook().transactions(self.user.prison)(self.user.pk).patch(
                 [{'id': t_id, 'credited': True} for t_id in to_credit]
             )
 
         # discard
         if to_discard:
-            self.client.transactions(self.user.prison)(self.user.pk).release.post({
+            self.client.cashbook().transactions(self.user.prison)(self.user.pk).release.post({
                 'transaction_ids': list(to_discard)
             })
 

--- a/mtp_cashbook/apps/cashbook/tests/test_forms.py
+++ b/mtp_cashbook/apps/cashbook/tests/test_forms.py
@@ -24,6 +24,7 @@ class ProcessTransactionBatchFormTestCase(SimpleTestCase):
 
     def test_init_form_with_already_locked_transactions(self):
         self.mocked_get_connection().\
+            cashbook().\
             transactions()().\
             get.return_value = self.pending_transactions_response
 
@@ -36,7 +37,9 @@ class ProcessTransactionBatchFormTestCase(SimpleTestCase):
         self.assertEqual(form.fields['transactions'].choices, expected_choices)
 
     def test_init_form_with_no_locked_transactions(self):
-        self.mocked_get_connection().transactions()().get.side_effect = [
+        self.mocked_get_connection().\
+            cashbook().\
+            transactions()().get.side_effect = [
             {
                 'count': 0,
                 'results': 0
@@ -55,6 +58,7 @@ class ProcessTransactionBatchFormTestCase(SimpleTestCase):
         Tests that [2, 3] gets credited and [1, 4] discarded
         """
         self.mocked_get_connection().\
+            cashbook().\
             transactions()().\
             get.return_value = self.pending_transactions_response
 
@@ -69,7 +73,7 @@ class ProcessTransactionBatchFormTestCase(SimpleTestCase):
         form.save()
 
         # checking call to patch
-        mocked_patch = form.client.transactions()().patch
+        mocked_patch = form.client.cashbook().transactions()().patch
         self.assertEqual(mocked_patch.call_count, 1)
         credited_transactions = mocked_patch.call_args[0][0]
         self.assertListEqual(
@@ -78,7 +82,7 @@ class ProcessTransactionBatchFormTestCase(SimpleTestCase):
         )
 
         # checking call to release
-        mocked_release = form.client.transactions()().release.post
+        mocked_release = form.client.cashbook().transactions()().release.post
         self.assertEqual(mocked_release.call_count, 1)
         discarded_transactions = mocked_release.call_args[0][0]
         self.assertListEqual(
@@ -91,6 +95,7 @@ class ProcessTransactionBatchFormTestCase(SimpleTestCase):
         Tests that all the transactions get credited.
         """
         self.mocked_get_connection().\
+            cashbook().\
             transactions()().\
             get.return_value = self.pending_transactions_response
 
@@ -105,7 +110,7 @@ class ProcessTransactionBatchFormTestCase(SimpleTestCase):
         form.save()
 
         # checking call to patch
-        mocked_patch = form.client.transactions()().patch
+        mocked_patch = form.client.cashbook().transactions()().patch
         self.assertEqual(mocked_patch.call_count, 1)
         credited_transactions = mocked_patch.call_args[0][0]
         self.assertListEqual(
@@ -114,7 +119,7 @@ class ProcessTransactionBatchFormTestCase(SimpleTestCase):
         )
 
         # checking that no call to release has been made
-        mocked_release = form.client.transactions()().release.post
+        mocked_release = form.client.cashbook().transactions()().release.post
         self.assertEqual(mocked_release.call_count, 0)
 
     def test_discard_all(self):
@@ -123,6 +128,7 @@ class ProcessTransactionBatchFormTestCase(SimpleTestCase):
         selected to be credited.
         """
         self.mocked_get_connection().\
+            cashbook().\
             transactions()().\
             get.return_value = self.pending_transactions_response
 
@@ -138,11 +144,11 @@ class ProcessTransactionBatchFormTestCase(SimpleTestCase):
         form.save()
 
         # checking that no call to patch has been made
-        mocked_patch = form.client.transactions()().patch
+        mocked_patch = form.client.cashbook().transactions()().patch
         self.assertEqual(mocked_patch.call_count, 0)
 
         # checking call to release with all transactions
-        mocked_release = form.client.transactions()().release.post
+        mocked_release = form.client.cashbook().transactions()().release.post
         self.assertEqual(mocked_release.call_count, 1)
         discarded_transactions = mocked_release.call_args[0][0]
         self.assertListEqual(

--- a/mtp_cashbook/apps/cashbook/tests/test_views.py
+++ b/mtp_cashbook/apps/cashbook/tests/test_views.py
@@ -29,7 +29,7 @@ class DashboardViewTestCase(MTPBaseTestCase):
     def test_0_available_0_pending_gives_correct_new_count(self):
         self.login()
 
-        conn = self.mocked_api_client.get_connection().transactions()
+        conn = self.mocked_api_client.get_connection().cashbook().transactions()
         conn.get.return_value = {'count': 0}  # available
         conn().get.return_value = {'count': 0}  # pending
 
@@ -40,7 +40,7 @@ class DashboardViewTestCase(MTPBaseTestCase):
     def test_some_available_0_pending_gives_correct_new_count(self):
         self.login()
 
-        conn = self.mocked_api_client.get_connection().transactions()
+        conn = self.mocked_api_client.get_connection().cashbook().transactions()
         conn.get.return_value = {'count': 21}  # available
         conn().get.return_value = {'count': 0}  # pending
 
@@ -51,7 +51,7 @@ class DashboardViewTestCase(MTPBaseTestCase):
     def test_0_available_some_pending_gives_correct_new_count(self):
         self.login()
 
-        conn = self.mocked_api_client.get_connection().transactions()
+        conn = self.mocked_api_client.get_connection().cashbook().transactions()
         conn.get.return_value = {'count': 0}  # available
         conn().get.return_value = {'count': 3}  # pending
 
@@ -62,7 +62,7 @@ class DashboardViewTestCase(MTPBaseTestCase):
     def some_available_some_pending_gives_correct_new_count(self):
         self.login()
 
-        conn = self.mocked_api_client.get_connection().transactions()
+        conn = self.mocked_api_client.get_connection().cashbook().transactions()
         conn.get.return_value = {'count': 21}  # available
         conn().get.return_value = {'count': 3}  # pending
 

--- a/mtp_cashbook/apps/cashbook/views.py
+++ b/mtp_cashbook/apps/cashbook/views.py
@@ -23,7 +23,7 @@ class DashboardView(TemplateView):
 
         # new transactions == available + my pending
         user = self.request.user
-        transaction_client = self.client.transactions(user.prison)
+        transaction_client = self.client.cashbook().transactions(user.prison)
         available = transaction_client.get(status='available')
         my_pending = transaction_client(user.pk).get(status='pending')
         context_data['new_transactions'] = available['count'] + my_pending['count']


### PR DESCRIPTION
Changes needed after namespaced cashbook transactions endpoints.

previously: /transactions/
now: /cashbook/transactions/