### PR TITLE
Patch hopscotch highlight to fix image referance

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "hopscotch": "~0.2.5",
     "js-cookie": "~2.0.3",
     "jquery": "~1.11",
-    "hopscotch-highlight": "ministryofjustice/hopscotch-highlight#0.1.2",
+    "hopscotch-highlight": "ministryofjustice/hopscotch-highlight#0.1.3",
     "checked-polyfill": "rdebeasi/checked-polyfill"
   }
 }

--- a/mtp_cashbook/assets-src/stylesheets/app.scss
+++ b/mtp_cashbook/assets-src/stylesheets/app.scss
@@ -4,7 +4,9 @@ $images-dir: '/static/images/';
 
 // Vendor
 @import 'vendor/hopscotch';
-@import '../../hopscotch-highlight/src/stylesheets/hopscotch-highlight';
+
+// loaded from bower lib
+@import 'hopscotch-highlight/src/stylesheets/hopscotch-highlight';
 
 // Breakpoints
 @import '$breakpoints';

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -1,7 +1,8 @@
-/* jshint node: true, camelcase: false */
+/* jshint node: true */
 
 'use strict';
 
+var path = require('path');
 var paths = require('./_paths');
 var gulp = require('gulp');
 var sass = require('gulp-sass');
@@ -14,13 +15,14 @@ function getBowerDir () {
     .file({ file: './.bowerrc' })
     .load();
 
-  return __dirname + '/../' + nconf.get('directory') + '/';
+  return path.join(__dirname, '..', nconf.get('directory'));
 }
 
 function getModulePaths (module) {
-  var modulePath = getBowerDir() + module + '/paths.json';
+  var modulePath = path.join(getBowerDir(), module, 'paths.json');
   var obj = require(modulePath);
 
+  /* jshint camelcase: false */
   return obj.import_paths;
 }
 
@@ -30,9 +32,11 @@ function getLoadPaths () {
   var mojularImportPaths = getModulePaths('mojular');
   var joined = govukImportPaths.concat(mojularImportPaths);
 
-  return joined.map(function(path) {
-    return bowerDir + '/' + path;
+  joined = joined.map(function(originalPath) {
+    return path.join(bowerDir, originalPath);
   });
+
+  return joined.concat(bowerDir);
 }
 
 


### PR DESCRIPTION
## User story [#104003626](https://www.pivotaltracker.com/story/show/104003626)

Image reference was incorrect for fallback image which meant IE8 wasn't getting a semi transparent background.

[Delivers #104003626]

**Before:**
![before-fix](https://cloud.githubusercontent.com/assets/3327997/10048654/ee408a88-620b-11e5-81be-55ae44052e30.png)

**After:**
![after-fix](https://cloud.githubusercontent.com/assets/3327997/10048661/f5b15c48-620b-11e5-9bd2-74e0b449e2d9.png)