### PR TITLE
Remove auth prefix from login urls

### DIFF
--- a/mtp_cashbook/urls.py
+++ b/mtp_cashbook/urls.py
@@ -3,6 +3,6 @@ from django.conf.urls import patterns, include, url
 
 urlpatterns = patterns(
     '',
-    url(r'^auth/', include('mtp_auth.urls', namespace='auth',)),
+    url(r'^', include('mtp_auth.urls', namespace='auth',)),
     url(r'^', include('cashbook.urls')),
 )


### PR DESCRIPTION
For consistency with the other front-end applications.