### PR TITLE
Remove 'auth' URL namespace for consistency with other front-ends

### DIFF
--- a/mtp_cashbook/apps/core/testing/testcases.py
+++ b/mtp_cashbook/apps/core/testing/testcases.py
@@ -11,11 +11,11 @@ class MTPBaseTestCase(SimpleTestCase):
 
     @property
     def login_url(self):
-        return reverse('auth:login')
+        return reverse('login')
 
     @property
     def logout_url(self):
-        return reverse('auth:logout')
+        return reverse('logout')
 
     @cached_property
     def _default_login_data(self):

--- a/mtp_cashbook/apps/mtp_auth/urls.py
+++ b/mtp_cashbook/apps/mtp_auth/urls.py
@@ -10,7 +10,7 @@ urlpatterns = patterns('',
     url(
         r'^logout/$', views.logout, {
             'template_name': 'mtp_auth/login.html',
-            'next_page': reverse_lazy('auth:login'),
+            'next_page': reverse_lazy('login'),
         }, name='logout'
     ),
 )

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -157,7 +157,7 @@ API_CLIENT_ID = 'cashbook'
 API_CLIENT_SECRET = os.environ.get('API_CLIENT_SECRET', 'cashbook')
 API_URL = os.environ.get('API_URL', 'http://localhost:8000')
 
-LOGIN_URL = 'auth:login'
+LOGIN_URL = 'login'
 LOGIN_REDIRECT_URL = 'dashboard'
 
 OAUTHLIB_INSECURE_TRANSPORT = True

--- a/mtp_cashbook/templates/base.html
+++ b/mtp_cashbook/templates/base.html
@@ -32,7 +32,7 @@
     Logged in as {{ full_name }}
     {% endblocktrans %}
     <span>
-      <a href="{% url 'auth:logout' %}">{% trans "Sign out" %}</a>
+      <a href="{% url 'logout' %}">{% trans "Sign out" %}</a>
     </span>
     <span>
       <a href="#" class="js-FeatureTour-start" id="tour-resume">{% trans "Help" %}</a>

--- a/mtp_cashbook/urls.py
+++ b/mtp_cashbook/urls.py
@@ -3,6 +3,6 @@ from django.conf.urls import patterns, include, url
 
 urlpatterns = patterns(
     '',
-    url(r'^', include('mtp_auth.urls', namespace='auth',)),
+    url(r'^', include('mtp_auth.urls')),
     url(r'^', include('cashbook.urls')),
 )


### PR DESCRIPTION
This is to make it easier to reuse templates across the different
projects.