### PR TITLE
Add Sentry exception handling for JavaScript

### DIFF
--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -98,7 +98,6 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'moj_utils.context_processors.debug',
                 'moj_utils.context_processors.analytics',
             ],
         },

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.join(BASE_DIR, 'apps'))
 
 get_project_dir = partial(join, BASE_DIR)
 
+APP = 'cashbook'
 ENVIRONMENT = os.environ.get('ENV', 'local')
 
 
@@ -99,6 +100,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'moj_utils.context_processors.analytics',
+                'moj_utils.context_processors.app_environment',
             ],
         },
     },

--- a/mtp_cashbook/templates/base.html
+++ b/mtp_cashbook/templates/base.html
@@ -1,5 +1,11 @@
 {% extends 'mtp_base.html' %}
 {% load i18n %}
+{% load moj_utils %}
+
+{% block main_js %}
+  {{ block.super }}
+  {% sentry_js %}
+{% endblock %}
 
 {% block page_title %}{% trans "Digital cashbook" %}{% endblock %}
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "money-to-prisoners-common": "ministryofjustice/money-to-prisoners-common#1.0.9"
+    "money-to-prisoners-common": "ministryofjustice/money-to-prisoners-common#1.0.10"
   }
 }


### PR DESCRIPTION
depends on [django-utils#7](https://github.com/ministryofjustice/django-utils/pull/7)

NB: tests will likely fail until that PR is merged