### PR TITLE
Add python functional tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ mtp_cashbook/assets/
 
 # failed test screenshots
 test/errorshots/
+
+# ghostdriver
+ghostdriver.log

--- a/mtp_cashbook/apps/cashbook/tests/test_browser.py
+++ b/mtp_cashbook/apps/cashbook/tests/test_browser.py
@@ -1,0 +1,49 @@
+from django.test import LiveServerTestCase
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+
+class TestTwo(LiveServerTestCase):
+
+    def __login(self, username, password):
+        self.driver.get(self.live_server_url)
+        login_field = self.driver.find_element_by_id('id_username')
+        login_field.send_keys(username)
+        password_field = self.driver.find_element_by_id('id_password')
+        password_field.send_keys(password + Keys.RETURN)
+
+    def test_title(self):
+        self.driver.get(self.live_server_url)
+        heading = self.driver.find_element_by_tag_name('h1')
+        self.assertEquals('Money sent to prisoners', heading.text)
+        self.assertEquals('32px', heading.value_of_css_property('font-size'))
+
+
+    def test_bad_login(self):
+        self.__login('test-prison-1', 'bad-password')
+        self.assertIn('There was a problem submitting the form',
+                      self.driver.page_source)
+
+    def test_good_login(self):
+        self.__login('test-prison-1', 'test-prison-1')
+        self.assertEquals(self.driver.current_url, self.live_server_url + '/')
+        self.assertIn('Credits to process', self.driver.page_source)
+
+
+
+    def setUp(self):
+        self.driver = webdriver.PhantomJS()
+
+    def tearDown(self):
+        self.driver.quit()
+
+    def _pre_setup(self, **kwargs):
+        """ Override the test database creation """
+        pass
+
+    def _post_teardown(self, **kwargs):
+        """ Override the test database deletion """
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mtp_cashbook/apps/cashbook/tests/test_functional.py
+++ b/mtp_cashbook/apps/cashbook/tests/test_functional.py
@@ -42,3 +42,9 @@ class FunctionalTestCase(LiveServerTestCase):
         self._login('test-prison-1', 'test-prison-1')
         self.assertEquals(self.driver.current_url, self.live_server_url + '/')
         self.assertIn('Credits to process', self.driver.page_source)
+
+    def test_logout(self):
+        self._login('test-prison-1', 'test-prison-1')
+        logout_link = self.driver.find_element_by_link_text('Sign out')
+        logout_link.click()
+        self.assertEqual(self.driver.current_url.split('?')[0], self.live_server_url + '/login/')

--- a/mtp_cashbook/apps/cashbook/tests/test_functional.py
+++ b/mtp_cashbook/apps/cashbook/tests/test_functional.py
@@ -10,7 +10,8 @@ class FunctionalTestCase(LiveServerTestCase):
         return []
 
     def setUp(self):
-        self.driver = webdriver.PhantomJS(executable_path='./node_modules/.bin/phantomjs')
+        path = './node_modules/phantomjs/lib/phantom/bin/phantomjs'
+        self.driver = webdriver.PhantomJS(executable_path=path)
 
     def tearDown(self):
         self.driver.quit()

--- a/mtp_cashbook/apps/cashbook/tests/test_functional.py
+++ b/mtp_cashbook/apps/cashbook/tests/test_functional.py
@@ -1,8 +1,12 @@
+import os
+import unittest
+
 from django.test import LiveServerTestCase
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 
 
+@unittest.skipUnless('RUN_FUNCTIONAL_TESTS' in os.environ, 'functional tests are disabled')
 class FunctionalTestCase(LiveServerTestCase):
     @classmethod
     def _databases_names(cls, include_mirrors=True):

--- a/mtp_cashbook/apps/cashbook/tests/test_functional.py
+++ b/mtp_cashbook/apps/cashbook/tests/test_functional.py
@@ -2,9 +2,20 @@ from django.test import LiveServerTestCase
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 
-class TestTwo(LiveServerTestCase):
 
-    def __login(self, username, password):
+class FunctionalTestCase(LiveServerTestCase):
+    @classmethod
+    def _databases_names(cls, include_mirrors=True):
+        # this app has no databases
+        return []
+
+    def setUp(self):
+        self.driver = webdriver.PhantomJS(executable_path='./node_modules/.bin/phantomjs')
+
+    def tearDown(self):
+        self.driver.quit()
+
+    def _login(self, username, password):
         self.driver.get(self.live_server_url)
         login_field = self.driver.find_element_by_id('id_username')
         login_field.send_keys(username)
@@ -17,33 +28,12 @@ class TestTwo(LiveServerTestCase):
         self.assertEquals('Money sent to prisoners', heading.text)
         self.assertEquals('32px', heading.value_of_css_property('font-size'))
 
-
     def test_bad_login(self):
-        self.__login('test-prison-1', 'bad-password')
+        self._login('test-prison-1', 'bad-password')
         self.assertIn('There was a problem submitting the form',
                       self.driver.page_source)
 
     def test_good_login(self):
-        self.__login('test-prison-1', 'test-prison-1')
+        self._login('test-prison-1', 'test-prison-1')
         self.assertEquals(self.driver.current_url, self.live_server_url + '/')
         self.assertIn('Credits to process', self.driver.page_source)
-
-
-
-    def setUp(self):
-        self.driver = webdriver.PhantomJS()
-
-    def tearDown(self):
-        self.driver.quit()
-
-    def _pre_setup(self, **kwargs):
-        """ Override the test database creation """
-        pass
-
-    def _post_teardown(self, **kwargs):
-        """ Override the test database deletion """
-        pass
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "money-to-prisoners-common": "ministryofjustice/money-to-prisoners-common"
+    "money-to-prisoners-common": "ministryofjustice/money-to-prisoners-common",
+    "phantomjs": "^1.9.19"
   }
 }

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,3 +4,5 @@ responses==0.4.0
 flake8==2.4.1
 pep8-naming==0.3.3
 django-template-i18n-lint==1.2.1
+selenium==2.48.0
+

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,8 +1,7 @@
 # Place your development dependencies here
 -r base.txt
-responses==0.4.0
+django-template-i18n-lint==1.2.1
 flake8==2.4.1
 pep8-naming==0.3.3
-django-template-i18n-lint==1.2.1
-selenium==2.48.0
-
+responses==0.4.0
+selenium==2.48


### PR DESCRIPTION
Not to be merged, but demonstrating a proposal to replace JS functional tests and implement them as Django tests instead. 

The proposal includes no longer using cucumber as the team doesn't have a workflow where plain language tests are necessary. This would remove the complexity to translate the cucumber tests into js+webdriver. Moving the new django tests along with the existing unit tests makes it simpler to run and maintain the whole test suite in one go.

To be discussed.