### PR TITLE
Remove more full stops at the end of error messages

### DIFF
--- a/mtp_cashbook/apps/cashbook/forms.py
+++ b/mtp_cashbook/apps/cashbook/forms.py
@@ -183,7 +183,7 @@ class FilterTransactionHistoryForm(GARequestErrorReportingMixin, forms.Form):
         start = self.cleaned_data.get('start')
         end = self.cleaned_data.get('end')
         if start and end and start > end:
-            self.add_error('end', ugettext('The end date must be after the start date.'))
+            self.add_error('end', ugettext('The end date must be after the start date'))
         return super().clean()
 
     @property

--- a/mtp_cashbook/assets-src/stylesheets/app.scss
+++ b/mtp_cashbook/assets-src/stylesheets/app.scss
@@ -7,16 +7,6 @@ $images-dir: '/static/images/';
 // app-specific
 .help-box { width: 65% }
 
-// Text only for screen readers
-.screenreader-only {
-  height: 1px;
-  width: 1px;
-  position: absolute;
-  overflow: hidden;
-  top: -10px;
-}
-
-
 // Page specific styles
 @import 'views/batch';
 @import 'views/history';

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]==3.5.0
+money-to-prisoners-common[testing]==3.6.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]==3.5.0
+money-to-prisoners-common[monitoring]==3.6.0
 
 uWSGI==2.0.12


### PR DESCRIPTION
visually; they're still there for screen readers