### PR TITLE
Display 'anonymous' payments in cashbook history screen

### DIFF
--- a/mtp_cashbook/assets-src/stylesheets/views/_history.scss
+++ b/mtp_cashbook/assets-src/stylesheets/views/_history.scss
@@ -83,6 +83,10 @@ form.HistorySearch {
   background: #FFD9D9;
 }
 
+.HistoryHeader-anonymous {
+  background: #F47738;
+}
+
 .inline .block-label {
   margin-top: 0;
 }

--- a/mtp_cashbook/templates/cashbook/credits_history.html
+++ b/mtp_cashbook/templates/cashbook/credits_history.html
@@ -64,13 +64,15 @@
         {% for credit_status, credits in group %}
           <table id="HistoryBatch-{{ forloop.parentloop.counter }}-{{ forloop.counter }}">
             <caption
-              class="HistoryHeader {% if credit_status == 'uncredited' %}HistoryHeader-uncredited{% elif credit_status == 'refunded' %}HistoryHeader-refunded{% endif %}">
-                {% if credit_status == 'uncredited' %}
-                  {% trans 'Uncredited' %}
+              class="HistoryHeader {% if credit_status == 'uncredited' %}HistoryHeader-uncredited{% elif credit_status == 'refunded' %}HistoryHeader-refunded{% elif credit_status == 'anonymous' %}HistoryHeader-anonymous{% endif %}">
+                {% if credit_status == 'credited' %}
+                  {% trans 'Credited' %}
                 {% elif credit_status == 'refunded' %}
                   {% trans 'Refunded' %}
+                {% elif credit_status == 'anonymous' %}
+                  {% trans 'Anonymous' %}
                 {% else %}
-                  {% trans 'Credited' %}
+                  {% trans 'Uncredited' %}
                 {% endif %}
               <span class="HistoryHeader-aside HistoryHeader-aside-right">{% trans 'Total' %}: £{{ credits|sum_credits|currency }}</span>
             </caption>


### PR DESCRIPTION
Anonymous payments are displayed separately to other payments
and have an orange banner.