### PR TITLE
Remove non-local email address from functional tests

### DIFF
--- a/mtp_cashbook/apps/cashbook/tests/test_functional.py
+++ b/mtp_cashbook/apps/cashbook/tests/test_functional.py
@@ -367,7 +367,7 @@ class AdminPagesTests(CashbookTestCase):
         self.type_in('id_username', username)
         self.type_in('id_first_name', 'Joe')
         self.type_in('id_last_name', 'Bloggs')
-        self.type_in('id_email', 'a@v.com')
+        self.type_in('id_email', 'a@v.local')
         self.driver.find_element_by_css_selector('form').submit()
 
     def test_list_page(self):


### PR DESCRIPTION
This fills up the Mailgun log with complaints about being unable
to find the MX record at v.com.