### PR TITLE
remove Mojular:

### DIFF
--- a/mtp_cashbook/assets-src/javascripts/main.js
+++ b/mtp_cashbook/assets-src/javascripts/main.js
@@ -3,27 +3,19 @@
 (function() {
   'use strict';
 
-  var Mojular = require('mojular');
+  require('dialog').Dialog.init();
+  require('collapsing-table').CollapsingTable.init();
+  require('messages').Messages.init();
+  require('print').Print.init();
+  require('polyfills').Polyfills.init();
+  require('select-all').SelectAll.init();
+  require('unload').Unload.init();
+  require('help-popup').HelpPopup.init();
+  require('analytics').Analytics.init();
+  require('track-printing').TrackPrinting.init();
 
-  Mojular
-    .use([
-      require('mojular-govuk-elements'),
-      require('mojular-moj-elements'),
-      require('dialog'),
-      require('collapsing-table'),
-      require('messages'),
-      require('print'),
-      require('polyfills'),
-      require('select-all'),
-      require('unload'),
-      require('help-popup'),
-      require('analytics'),
-      require('track-printing'),
-
-      require('batch-validation'),
-      require('sticky-header'),
-      require('running-total'),
-      require('search-focus')
-    ])
-    .init();
+  require('batch-validation').BatchValidation.init();
+  require('sticky-header').StickyHeader.init();
+  require('running-total').RunningTotal.init();
+  require('search-focus').SearchFocus.init();
 }());

--- a/mtp_cashbook/assets-src/javascripts/modules/batch-validation.js
+++ b/mtp_cashbook/assets-src/javascripts/modules/batch-validation.js
@@ -20,7 +20,7 @@ exports.BatchValidation = {
   },
 
   bindEvents: function () {
-    this.base.Events.on('BatchValidation.render', this.render);
+    this.$body.on('BatchValidation.render', this.render);
     this.$form.on('click', ':submit', $.proxy(this.onSubmit, this));
   },
 
@@ -71,12 +71,12 @@ exports.BatchValidation = {
     if (!checkedValid && numChecked > 0) {
       // Partial: ask for confirmation
       e.preventDefault();
-      this.base.Events.trigger({
+      this.$body.trigger({
         type: 'Dialog.render',
         target: e.target,
         targetSelector: '#incomplete-batch-dialog'
       });
-      analytics.analytics.send('pageview', '/batch/-dialog_open/');
+      analytics.Analytics.send('pageview', '/batch/-dialog_open/');
       return;
     }
   }

--- a/mtp_cashbook/assets-src/javascripts/modules/running-total.js
+++ b/mtp_cashbook/assets-src/javascripts/modules/running-total.js
@@ -15,6 +15,7 @@ exports.RunningTotal = {
   },
 
   cacheEls: function () {
+    this.$body = $('body');
     this.$items = $('.js-RunningTotal-item');
     this.$totalsContainer = $(this.selector);
     this.labelText = this.$totalsContainer.data('label');
@@ -24,7 +25,7 @@ exports.RunningTotal = {
   },
 
   bindEvents: function () {
-    this.base.Events.on('RunningTotal.render', $.proxy(this.render, this));
+    this.$body.on('RunningTotal.render', $.proxy(this.render, this));
     this.$items.on('change', $.proxy(this.updateTotal, this));
   },
 

--- a/mtp_cashbook/assets-src/javascripts/modules/sticky-header.js
+++ b/mtp_cashbook/assets-src/javascripts/modules/sticky-header.js
@@ -9,7 +9,6 @@ exports.StickyHeader = {
 
   init: function () {
     this.cacheEls();
-
     if (this.$originalHeader.length) {
       this.bindEvents();
       this.render();
@@ -28,7 +27,7 @@ exports.StickyHeader = {
   },
 
   bindEvents: function () {
-    this.base.Events.on('StickyHeader.render', $.proxy(this.render, this));
+    this.$body.on('StickyHeader.render', $.proxy(this.render, this));
     this.$window.scroll($.proxy(this.onScroll, this));
   },
 

--- a/mtp_cashbook/assets-src/stylesheets/app-ie6.scss
+++ b/mtp_cashbook/assets-src/stylesheets/app-ie6.scss
@@ -1,0 +1,7 @@
+@charset 'UTF-8';
+
+$is-ie: true;
+$ie-version: 6;
+$mobile-ie6: false;
+
+@import 'app';

--- a/mtp_cashbook/assets-src/stylesheets/app-ie7.scss
+++ b/mtp_cashbook/assets-src/stylesheets/app-ie7.scss
@@ -1,0 +1,6 @@
+@charset 'UTF-8';
+
+$is-ie: true;
+$ie-version: 7;
+
+@import 'app';

--- a/mtp_cashbook/assets-src/stylesheets/app-ie8.scss
+++ b/mtp_cashbook/assets-src/stylesheets/app-ie8.scss
@@ -1,0 +1,10 @@
+@charset 'UTF-8';
+
+$is-ie: true;
+$ie-version: 8;
+
+@import 'app';
+
+.Dialog .button-secondary {
+    font-weight: bold;
+}

--- a/mtp_cashbook/assets-src/stylesheets/app.scss
+++ b/mtp_cashbook/assets-src/stylesheets/app.scss
@@ -4,10 +4,14 @@ $images-dir: '/static/images/';
 
 @import 'mtp';
 
-// app-specific
-.help-box { width: 65% }
-
 // Page specific styles
 @import 'views/batch';
 @import 'views/history';
 @import 'views/locked';
+
+// app-specific
+.help-box { width: 65% }
+
+.form-group {
+  margin-bottom: 10px;
+}

--- a/mtp_cashbook/assets-src/stylesheets/views/_batch.scss
+++ b/mtp_cashbook/assets-src/stylesheets/views/_batch.scss
@@ -26,7 +26,8 @@
     }
 
     .container {
-      margin-top: 1.5em;
+      max-width: $site-width;
+      margin: 1.5em auto 0 auto;
     }
 
     &.is-sticky {
@@ -36,12 +37,12 @@
       left: 0;
       width: 100%;
       margin: 0;
-      padding: em(12) 0;
+      padding: .5em 1em;
       border: 0;
       background: #FDED95;
 
       p {
-        font-size: em(19);
+        font-size: 1.2em;
         margin-top: 0;
         margin-bottom: 0;
         span:nth-child(2) {

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -94,8 +94,8 @@ TEMPLATES = [
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
             get_project_dir('templates'),
-            get_project_dir('node_modules'),
-            get_project_dir('../node_modules/mojular-templates'),
+            get_project_dir('assets/templates'),
+            get_project_dir('node_modules')
         ],
         'APP_DIRS': True,
         'OPTIONS': {

--- a/mtp_cashbook/settings/docker.py
+++ b/mtp_cashbook/settings/docker.py
@@ -2,6 +2,7 @@
 Docker settings
 """
 from .base import *  # noqa
+from .base import os, ENVIRONMENT
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')

--- a/mtp_cashbook/settings/jenkins.py
+++ b/mtp_cashbook/settings/jenkins.py
@@ -1,5 +1,5 @@
 from .base import *  # noqa
-
+from .base import INSTALLED_APPS
 
 INSTALLED_APPS += (
     'django_jenkins',

--- a/mtp_cashbook/templates/cashbook/credit_batch_list.html
+++ b/mtp_cashbook/templates/cashbook/credit_batch_list.html
@@ -5,13 +5,13 @@
 
 {% block page_title %}{% trans "New credits - Digital cashbook" %}{% endblock %}
 
-{% block template_type %}v-batch{% endblock %}
+{% block body_classes %}v-batch{% endblock %}
 
-{% block content %}
+{% block inner_content %}
 
   <header class="ContentHeader">
     <a id="header-home-link" href="{% url 'dashboard-batch-discard' %}" class="ContentHeader-back">{% trans 'Home' %}</a>
-    <h1>{% trans 'New credits' %}</h1>
+    <h1 class="heading-xlarge">{% trans 'New credits' %}</h1>
   </header>
 
   {% include "mtp_common/includes/message_box.html" %}
@@ -34,7 +34,7 @@
         <div class="help-box-title" aria-controls="help-box-contents" aria-expanded="true" role="heading">
           <div></div><a href="#">{% trans 'Help' %}</a>
         </div>
-        <div class="panel-indent help-box-contents" id="help-box-contents">
+        <div class="panel help-box-contents" id="help-box-contents">
           {% blocktrans trimmed %}
             <p>How to use the Digital Cashbook with NOMIS:</p>
             <ul>
@@ -114,10 +114,11 @@
       <p>{% trans "There aren’t any credits available" %}</p>
     {% endif %}
 
-    <dialog id="incomplete-batch-dialog"
-            class="Dialog u-nojs-hidden"
-            data-hide-close="true"
-            data-disable-backdrop-close="true">
+    <div id="incomplete-batch-dialog"
+         class="Dialog u-nojs-hidden"
+         style="display: none"
+         data-hide-close="true"
+         data-disable-backdrop-close="true">
       <div class="Dialog-inner">
         <p><strong>{% trans "Do you want to submit only the selected credits?" %}</strong></p>
         <button type="submit"
@@ -127,9 +128,9 @@
                 class="button button-secondary js-Dialog-close"
                 data-analytics="pageview,/batch/-dialog_close/">{% trans "No, continue processing" %}</button>
       </div>
-    </dialog>
+    </div>
   </form>
 
   {% include "cashbook/includes/print_dialog.html" %}
 
-{% endblock content %}
+{% endblock %}

--- a/mtp_cashbook/templates/cashbook/credits_history.html
+++ b/mtp_cashbook/templates/cashbook/credits_history.html
@@ -4,10 +4,10 @@
 {% load mtp_common %}
 {% load credits %}
 
-{% block content %}
+{% block inner_content %}
   <header class="ContentHeader">
     <a href="{% url 'dashboard' %}" class="ContentHeader-back">{% trans 'Home' %}</a>
-    <h1>{% trans 'Credit history' %}</h1>
+    <h1 class="heading-xlarge">{% trans 'Credit history' %}</h1>
   </header>
 
   <div class="help-box">
@@ -16,7 +16,7 @@
     <div class="help-box-title" aria-controls="help-box-contents" aria-expanded="true" role="heading">
       <div></div><a href="#">{% trans 'Help' %}</a>
     </div>
-    <div class="panel-indent help-box-contents" id="help-box-contents">
+    <div class="panel help-box-contents" id="help-box-contents">
       <p>{% trans 'To help with your search:' %}</p>
       <ul>
         <li>{% trans 'Search by prisoner name, prisoner number, sender name or amount' %}</li>
@@ -59,7 +59,7 @@
       <p class="HistoryDescription">{{ form.get_search_description }}</p>
 
       {% for credit_date, group in object_list|parse_date_fields|regroup_credits %}
-        <h3>{{ credit_date|date:'DATE_FORMAT' }}</h3>
+        <h2 class="heading-medium">{{ credit_date|date:'DATE_FORMAT' }}</h2>
 
         {% for credit_status, credits in group %}
           <table id="HistoryBatch-{{ forloop.parentloop.counter }}-{{ forloop.counter }}" class="CollapsingTable">
@@ -136,4 +136,4 @@
     {% endif %}
   </div>
 
-{% endblock content %}
+{% endblock %}

--- a/mtp_cashbook/templates/cashbook/credits_locked.html
+++ b/mtp_cashbook/templates/cashbook/credits_locked.html
@@ -3,10 +3,10 @@
 {% load currency %}
 {% load mtp_common %}
 
-{% block content %}
+{% block inner_content %}
   <header class="ContentHeader">
     <a href="{% url 'dashboard' %}" class="ContentHeader-back">{% trans 'Home' %}</a>
-    <h1>{% trans 'Credits in progress' %}</h1>
+    <h1 class="heading-xlarge">{% trans 'Credits in progress' %}</h1>
   </header>
 
   {% include "mtp_common/includes/message_box.html" %}
@@ -22,7 +22,7 @@
         <div class="help-box-title" aria-controls="help-box-contents" aria-expanded="true" role="heading">
           <div></div><a href="#">{% trans 'Help' %}</a>
         </div>
-        <div class="panel-indent help-box-contents" id="help-box-contents">
+        <div class="panel help-box-contents" id="help-box-contents">
           {% blocktrans trimmed %}
             <p>If you want to release credits:</p>
             <ul>
@@ -87,4 +87,4 @@
       <p>{% trans "No credits in progress" %}</p>
     {% endif %}
   </form>
-{% endblock content %}
+{% endblock %}

--- a/mtp_cashbook/templates/cashbook/dashboard.html
+++ b/mtp_cashbook/templates/cashbook/dashboard.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block content %}
+{% block inner_content %}
   <p>{% trans "Home" %}</p>
 
   {% include "mtp_common/includes/message_box.html" %}
@@ -10,9 +10,9 @@
     <div class="help-box-title" aria-controls="help-box-contents" aria-expanded="true" role="heading">
       <div></div><a href="#">{% trans 'Help' %}</a>
     </div>
-    <div class="panel-indent help-box-contents" id="help-box-contents">
+    <div class="panel help-box-contents" id="help-box-contents">
       <p>{% trans 'You can click on:' %}</p>
-      <ul>
+      <ul class="list list-bullet">
         <li>{% trans '‘New’ to process credits in NOMIS' %}</li>
         <li>{% trans '‘History’ to view all credits processed' %}</li>
         <li>{% trans '‘In progress’ to view credits currently being processed by your team' %}</li>
@@ -51,4 +51,4 @@
     </li>
   </ul>
 
-{% endblock content %}
+{% endblock %}

--- a/mtp_cashbook/templates/cashbook/includes/print_dialog.html
+++ b/mtp_cashbook/templates/cashbook/includes/print_dialog.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<dialog id="print-dialog" class="Dialog">
+<div id="print-dialog" class="Dialog" style="display: none">
   <div class="Dialog-inner">
     <h3>{% trans "Do you need to print?" %}</h3>
     <p>{% trans 'Did you know:' %}</p>
@@ -17,4 +17,4 @@
     <button type="button" class="button u-nojs-hidden js-Print">{% trans 'Print' %}</button>
     <button type="button" class="button u-nojs-hidden js-Dialog-close">{% trans 'Cancel' %}</button>
   </div>
-</dialog>
+</div>

--- a/mtp_cashbook/templates/cashbook/includes/table_actions.html
+++ b/mtp_cashbook/templates/cashbook/includes/table_actions.html
@@ -5,7 +5,7 @@
       <a href="#print-dialog" class="js-Dialog">{% trans "Print these credits" %}</a>
     {% endif %}
   </td>
-  <td colspan="2" align="right" class="cell--compact cell--bold">
+  <td colspan="2" class="cell--compact cell--bold flush-right">
     {% if select_all != False %}
       <input type="checkbox" id="select-all-{{ location }}" class="Checkbox Checkbox--right js-SelectAll" data-name="{{ field_name }}">
       <label data-analytics="event,select-all,{{ location }}" for="select-all-{{ location }}">{% trans "Select all" %}</label>

--- a/mtp_cashbook/templates/feedback/submit_feedback.html
+++ b/mtp_cashbook/templates/feedback/submit_feedback.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block content %}
+{% block inner_content %}
 
 <header class="ContentHeader">
   <a href="{% url 'dashboard' %}" class="ContentHeader-back">{% trans 'Home' %}</a>
-  <h1>{% trans 'Your feedback' %}</h1>
+  <h1 class="heading-xlarge">{% trans 'Your feedback' %}</h1>
 </header>
 
 <form action="." method="post" id="send-feedback">
@@ -19,7 +19,7 @@
     {% with field=form.ticket_content %}
       <div class="form-group {% if field.errors %}error{% endif %}">
         {% include 'mtp_common/forms/field-label.html' with field=field only %}
-        <p><div class="panel-indent panel-border-wide">
+        <p><div class="panel panel-border-wide">
           {% trans 'Please don’t include bank details or any other personal information.' %}
         </div></p>
         {% include 'mtp_common/forms/field-errors.html' with field=field only %}
@@ -27,7 +27,7 @@
       </div>
     {% endwith %}
 
-    <h2>{% trans 'Do you want a reply?' %}</h2>
+    <h2 class="heading-large">{% trans 'Do you want a reply?' %}</h2>
     <p>{% trans 'Enter your email address if you’d like a reply. We won’t use it for anything else.' %}</p>
 
     {% include 'mtp_common/forms/field.html' with field=form.contact_email only %}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]==3.19.0
+money-to-prisoners-common[testing]==4.4.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]==3.19.0
+money-to-prisoners-common[monitoring]==4.4.0
 
 uWSGI==2.0.12

--- a/run.sh
+++ b/run.sh
@@ -38,10 +38,11 @@ COMMAND=$1
 APP=cashbook
 VIRTUAL_ENV_DIR=venv
 NODE_MODULES=node_modules
+GOVUK_TEMPLATE_VERSION=0.17.3
 
 case "$COMMAND" in
     clean)
-        rm -rf $VIRTUAL_ENV_DIR $NODE_MODULES static mtp_$APP/assets
+        rm -rf $VIRTUAL_ENV_DIR $NODE_MODULES static mtp_$APP/assets mtp_$APP/templates/govuk_template
         ;;
     serve | watch | docker | update | build | test | start)
         PORT=8001
@@ -72,7 +73,7 @@ case "$COMMAND" in
         else
             echo "Common resources found at $PYTHON_LIBS"
         fi
-        echo "Installing front-end assets"
+        echo "Installing npm front-end assets"
         npm install >/dev/null
         npm install `cat $PYTHON_LIBS/mtp_common/npm_requirements.txt` >/dev/null
         mkdir -p $MTP_COMMON_NODE_MODULES

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,11 +4,10 @@ var webpack = require('webpack');
 
 module.exports = {
   entry: {
-    app: './mtp_cashbook/assets-src/javascripts/main.js',
-    polyfills: ['JSON2', 'html5shiv']
+    app: './mtp_cashbook/assets-src/javascripts/main.js'
   },
   output: {
-    path: './mtp_cashbook/assets/scripts',
+    path: './mtp_cashbook/assets/javascripts',
     filename: '[name].bundle.js'
   },
   module: {
@@ -21,8 +20,7 @@ module.exports = {
   },
   resolve: {
     root: [
-      __dirname + '/node_modules',
-      __dirname + '/node_modules/mojular-moj-elements/node_modules'
+      __dirname + '/node_modules'
     ],
     modulesDirectories: [
       './mtp_cashbook/assets-src/javascripts/modules',


### PR DESCRIPTION
* use latest common
* require js scripts the standard way
* add stylesheets for old ie versions
* align to govuk visual styles,
* use govuk classes, markup and template
* find new govuk-templates
* adapt run script and webpack config
* use display:none to avoid FOUCs
* Fix heading hierarchy
* remove <dialog> as not supported by the version of html5shiv in govuk_template
* remove align attribute (wtf)