### PR TITLE
Make credit ordering on history screen consistent

### DIFF
--- a/mtp_cashbook/apps/cashbook/templatetags/credits.py
+++ b/mtp_cashbook/apps/cashbook/templatetags/credits.py
@@ -53,13 +53,13 @@ def regroup_credits(credits):
         return 'uncredited'
 
     def get_status_order(c):
-        if not c['resolution'] == 'credited':
-            return 0
-        if not c['resolution'] == 'refunded':
-            return 1
-        if c['anonymous']:
+        if c['resolution'] == 'credited':
+            return 3
+        if c['resolution'] == 'refunded':
             return 2
-        return 3
+        if c['anonymous']:
+            return 1
+        return 0
 
     grouped_credits = OrderedDict()
     groups = groupby(credits, key=lambda c: c['received_at'].date() if c['received_at'] else None)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]==4.19.0
+money-to-prisoners-common[testing]==4.21.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]==4.19.0
+money-to-prisoners-common[monitoring]==4.21.0
 
 uWSGI==2.0.12


### PR DESCRIPTION
Previously anonymous and uncredited payments were being intermingled.