### PR TITLE
Show inactive 'change password' page when in test environment

### DIFF
--- a/mtp_cashbook/apps/cashbook/urls.py
+++ b/mtp_cashbook/apps/cashbook/urls.py
@@ -23,6 +23,6 @@ urlpatterns = [
 
     url(r'^service-overview/(?:(?P<page>[^/]+)/)?$', ServiceOverview.as_view(), name='service-overview'),
     url(r'^training/(?:(?P<page>[^/]+)/)?$', Training.as_view(), name='training'),
-    
+
     url(r'^inactive_password_change/$', inactive_password_change_view, name='inactive_password_change'),
 ]

--- a/mtp_cashbook/apps/cashbook/urls.py
+++ b/mtp_cashbook/apps/cashbook/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 
 from .views import CreditBatchListView, CreditsLockedView, \
-    CreditHistoryView, DashboardView
+    CreditHistoryView, DashboardView, inactive_password_change_view
 from .views_training import ServiceOverview, Training
 
 urlpatterns = [
@@ -23,4 +23,6 @@ urlpatterns = [
 
     url(r'^service-overview/(?:(?P<page>[^/]+)/)?$', ServiceOverview.as_view(), name='service-overview'),
     url(r'^training/(?:(?P<page>[^/]+)/)?$', Training.as_view(), name='training'),
+    
+    url(r'^inactive_password_change/$', inactive_password_change_view, name='inactive_password_change'),
 ]

--- a/mtp_cashbook/apps/cashbook/views.py
+++ b/mtp_cashbook/apps/cashbook/views.py
@@ -8,11 +8,16 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ngettext
 from django.views.generic import FormView, TemplateView
 from mtp_common.auth import api_client
+from django.shortcuts import render
 
 from .forms import ProcessCreditBatchForm, DiscardLockedCreditsForm, \
     FilterCreditHistoryForm
 
 logger = logging.getLogger('mtp')
+
+
+def inactive_password_change_view(request):
+    return render(request, 'cashbook/inactive_password_change.html')
 
 
 class DashboardView(TemplateView):

--- a/mtp_cashbook/assets-src/stylesheets/app.scss
+++ b/mtp_cashbook/assets-src/stylesheets/app.scss
@@ -13,9 +13,21 @@ $images-dir: '/static/images/';
 @import 'views/pagination';
 
 // mtp-common overrides
-.help-box div { width: 65% }
+.help-box div {
+  width: 65%;
+}
 
 // govuk_elements overrides
 .form-group {
   margin-bottom: 10px;
+}
+
+.mtp-inactive__form {
+  .form-label {
+    color: $grey-2;
+  }
+
+  .form-control {
+    border: 2px solid $grey-2;
+  }
 }

--- a/mtp_cashbook/templates/base.html
+++ b/mtp_cashbook/templates/base.html
@@ -23,7 +23,11 @@
 
 {% block user_menu %}
   <li>
-    <a href="{% url 'password_change' %}">{% trans 'Change password' %}</a>
+    {% if ENVIRONMENT == 'test' %}
+      <a href="{% url 'inactive_password_change' %}">{% trans 'Change password' %}</a>
+    {% else %}
+      <a href="{% url 'password_change' %}">{% trans 'Change password' %}</a>
+    {% endif %}
   </li>
   {% if perms.auth.change_user %}
     <li>

--- a/mtp_cashbook/templates/cashbook/inactive_password_change.html
+++ b/mtp_cashbook/templates/cashbook/inactive_password_change.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load mtp_common %}
+
+{% block inner_content %}
+  <a href="{% url 'dashboard' %}" class="ContentHeader-back">{% trans 'Home' %}</a>
+
+  <h2 class="heading-large">Change your password</h2>
+  <div class="mtp-inactive__form">
+    <div class="form-group">
+      <label class="form-label" for="old-password">{% trans 'Old password' %}</label>
+      <input class="form-control" id="old-password" name="old-password" type="text" disabled>
+    </div>
+    <div class="form-group">
+      <label class="form-label" for="new-password">{% trans 'New password' %}</label>
+      <input class="form-control" id="new-password" name="new-password" type="text" disabled>
+    </div>
+    <div class="form-group">
+      <label class="form-label" for="new-password-confirmation">{% trans 'New password confirmation' %}</label>
+      <input class="form-control" id="new-password-confirmation" name="new-password-confirmation" type="text" disabled>
+    </div>
+    <div class="panel panel-border-narrow">
+      {% trans 'During training it is not possible to change your password' %}
+    </div>
+  </div>
+
+{% endblock %}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]==4.29.0
+money-to-prisoners-common[testing]==4.30.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]==4.29.0
+money-to-prisoners-common[monitoring]==4.30.0
 
 uWSGI==2.0.12


### PR DESCRIPTION
- create inactive 'change password' template for test environment, so passwords cannot be altered during testing
- add url and view for 'inactive_password_change'
- add styling to grey out inactive form
- update requirements to use latest mtp-common version