### PR TITLE
Show screenshots correctly on IE8

### DIFF
--- a/mtp_cashbook/assets-src/stylesheets/views/_training.scss
+++ b/mtp_cashbook/assets-src/stylesheets/views/_training.scss
@@ -92,9 +92,10 @@
   .mtp-training-section__image {
     border: 1px solid $border-color;
     float: right;
+    max-width: 465px;
 
     img {
-      max-width: 465px;
+      max-width: 100%;
     }
   }
 


### PR DESCRIPTION
Screenshots were not being displayed correctly on IE8 as their
container maintained the unresized width or something like that.