### PR TITLE
Reorganise explanatory text on cashbook homepage

### DIFF
--- a/mtp_cashbook/assets-src/stylesheets/views/_dashboard.scss
+++ b/mtp_cashbook/assets-src/stylesheets/views/_dashboard.scss
@@ -48,6 +48,11 @@
   }
 }
 
+.heading-xlarge__chopped {
+  @extend .heading-xlarge;
+  margin-bottom: 20px;
+}
+
 .mtp-dashboard-training {
   clear: both;
 }

--- a/mtp_cashbook/templates/base.html
+++ b/mtp_cashbook/templates/base.html
@@ -48,3 +48,27 @@
     </ul>
   {% endif %}
 {% endblock %}
+
+{% block phase_banner %}
+  <div class="phase-banner-beta">
+    <p>
+      {% if ENVIRONMENT == 'prod' %}
+        <strong class="phase-tag">{% trans 'Beta' %}</strong>
+      {% else %}
+        <strong class="phase-tag phase-tag-dev" title="{{ APP }}-{{ ENVIRONMENT }}:{{ APP_GIT_COMMIT_SHORT }}{% if APP_BUILD_DATE %}, built {{ APP_BUILD_DATE }}{% endif %}">{{ ENVIRONMENT }}</strong>
+      {% endif %}
+      {% url 'submit_ticket' as ticket_url %}
+      <span>
+        {% if ENVIRONMENT == 'prod' %}
+          {% trans 'This is a new service.' %}
+        {% else %}
+          {% trans 'Please try out this site. The credits and prisoners listed are not real.' %}
+          {% trans 'All data on the digital cashbook training site will be reset every hour, on the hour.' %}
+        {% endif %}
+        {% blocktrans trimmed %}
+          If you have any comments or need help please <a href="{{ ticket_url }}">contact us</a>.
+        {% endblocktrans %}
+      </span>
+    </p>
+  </div>
+{% endblock %}

--- a/mtp_cashbook/templates/cashbook/dashboard.html
+++ b/mtp_cashbook/templates/cashbook/dashboard.html
@@ -4,21 +4,15 @@
 
 {% block inner_content %}
 
-  <h1 class="heading-xlarge">{% trans 'Digital cashbook' %}</h1>
+  <h1 class="heading-xlarge__chopped">{% trans 'Digital cashbook' %}</h1>
+
+  <div>
+      {% blocktrans trimmed %}
+        Credits received from the <a href="{{ start_page_url }}" target="_blank">‘Send money to a prisoner’</a> service
+      {% endblocktrans %}
+    </div>
 
   {% include "mtp_common/includes/message_box.html" %}
-
-  <p>
-    {% blocktrans trimmed %}
-      Credits received from the <a href="{{ start_page_url }}" target="_blank">‘Send money to a prisoner’</a> service.
-    {% endblocktrans %}
-  </p>
-  {% if ENVIRONMENT != 'prod' %}
-    <p>
-      {% trans 'Please try out this site. The credits and prisoners listed are not real.' %}
-      {% trans 'All data on the digital cashbook training site will be reset every hour, on the hour.' %}
-    </p>
-  {% endif %}
 
   <div class="grid-row">
     <div class="mtp-status-box"></div>


### PR DESCRIPTION
- Move the training site text to the phase banner.
- Move the explanatory blurb a bit closer to the header.