### PR TITLE
Adjust padding on collapsing header

### DIFF
--- a/mtp_cashbook/assets-src/stylesheets/views/_history.scss
+++ b/mtp_cashbook/assets-src/stylesheets/views/_history.scss
@@ -55,6 +55,8 @@
 }
 
 .mtp-history-header {
+  padding-right: 2em;
+
   &__credited {
     background: #cde2b7;
   }


### PR DESCRIPTION
- to stop right-hand totals being clipped on IE8

<img width="225" alt="screen shot 2016-11-24 at 12 33 49" src="https://cloud.githubusercontent.com/assets/13685520/20623856/8b302b7c-b301-11e6-91f7-11477f9d0eb9.png">