### PR TITLE
Always lock the maximum available credits

### DIFF
--- a/mtp_cashbook/apps/cashbook/forms.py
+++ b/mtp_cashbook/apps/cashbook/forms.py
@@ -53,10 +53,9 @@ class ProcessCreditBatchForm(GARequestErrorReportingMixin, forms.Form):
         Gets the credits currently locked by the user if they exist
         or locks some and returns them if not.
         """
-        credits = self._request_locked_credits()
-        if not self.is_bound and len(credits) == 0:
+        if not self.is_bound:
             self._take_credits()
-            credits = self._request_locked_credits()
+        credits = self._request_locked_credits()
 
         return [
             (t['id'], t) for t in credits

--- a/mtp_cashbook/apps/cashbook/tests/test_forms.py
+++ b/mtp_cashbook/apps/cashbook/tests/test_forms.py
@@ -25,7 +25,7 @@ class ProcessCreditBatchFormTestCase(SimpleTestCase):
         self.mocked_get_connection = mocked_get_connection
         super(ProcessCreditBatchFormTestCase, self).__call__(result, *args, **kwargs)
 
-    def test_init_form_with_already_locked_credits(self):
+    def test_init_form(self):
         self.mocked_get_connection().credits.get.return_value = self.locked_credits_response
 
         form = ProcessCreditBatchForm(self.request)
@@ -33,21 +33,7 @@ class ProcessCreditBatchFormTestCase(SimpleTestCase):
         expected_choices = [
             (t['id'], t) for t in self.locked_credits_response['results']
         ]
-        self.assertEqual(form.credit_choices, expected_choices)
-        self.assertEqual(form.fields['credits'].choices, expected_choices)
-
-    def test_init_form_with_no_locked_credits(self):
-        self.mocked_get_connection().credits.get.side_effect = [
-                {
-                    'count': 0,
-                    'results': []
-                },
-            ] + [self.locked_credits_response]
-
-        form = ProcessCreditBatchForm(self.request)
-        expected_choices = [
-            (t['id'], t) for t in self.locked_credits_response['results']
-        ]
+        self.mocked_get_connection().credits.actions.lock.post.assert_called_with()
         self.assertEqual(form.credit_choices, expected_choices)
         self.assertEqual(form.fields['credits'].choices, expected_choices)
 

--- a/mtp_cashbook/apps/cashbook/views.py
+++ b/mtp_cashbook/apps/cashbook/views.py
@@ -53,12 +53,13 @@ class DashboardView(TemplateView):
             reviewed = credit_client.get(status='available', reviewed=True)
             context_data['reviewed'] = reviewed['count']
 
+        new_credit_count = available['count'] + my_locked['count']
         context_data.update({
             'start_page_url': settings.START_PAGE_URL,
-            'new_credits': available['count'] + my_locked['count'],
+            'new_credits': new_credit_count,
             'locked_credits': locked['count'],
             'all_credits': all_credits['count'],
-            'batch_size': min(available['count'], 20),
+            'batch_size': min(new_credit_count, 20),
             'pre_approval_required': pre_approval_required
         })
         return context_data


### PR DESCRIPTION
Previously, when there are credits already locked to the user,
these will be presented without locking any more, even if there are
less than 20. Now if the user clicks "Next credits" when they have
they less than 20 locked, more available credits up to a total of
20 will be locked to them.