### PR TITLE
Maintain search parameters across multiple history pages

### DIFF
--- a/mtp_cashbook/apps/cashbook/forms.py
+++ b/mtp_cashbook/apps/cashbook/forms.py
@@ -1,6 +1,8 @@
+import collections
 from datetime import timedelta
 from functools import reduce
 from itertools import groupby
+from urllib.parse import urlencode
 
 from django import forms
 from django.conf import settings
@@ -307,3 +309,18 @@ class FilterCreditHistoryForm(GARequestErrorReportingMixin, forms.Form):
                 'credits': credit_description,
             }
         return capfirst(description)
+
+    def get_query_data(self):
+        data = collections.OrderedDict()
+        for field in self:
+            if field.name == 'page':
+                continue
+            value = self.cleaned_data.get(field.name)
+            if value in [None, '', []]:
+                continue
+            data[field.name] = value
+        return data
+
+    @cached_property
+    def query_string(self):
+        return urlencode(self.get_query_data(), doseq=True)

--- a/mtp_cashbook/templates/cashbook/credits_history.html
+++ b/mtp_cashbook/templates/cashbook/credits_history.html
@@ -126,7 +126,7 @@
         {% endfor %}
       {% endfor %}
 
-      {% page_list page=current_page page_count=page_count %}
+      {% page_list page=current_page page_count=page_count query_string=form.query_string %}
 
       <p><a href="#print-dialog" class="js-Dialog">{% trans 'Print this page of credits' %}</a></p>
       {% include 'cashbook/includes/print_dialog.html' %}


### PR DESCRIPTION
The page links on the history page were not including the current
query parameters.