### PR TITLE
Fix JS bug with running total summation

### DIFF
--- a/mtp_cashbook/assets-src/javascripts/modules/running-total.js
+++ b/mtp_cashbook/assets-src/javascripts/modules/running-total.js
@@ -41,7 +41,7 @@ exports.RunningTotal = {
 
     this.$items.each(function (i, el) {
       var $el = $(el);
-      var amount = $el.data('amount');
+      var amount = String($el.data('amount')).replace(',', '');
 
       if ($el.is(':checked')) {
         total += parseFloat(amount);


### PR DESCRIPTION
Larger credit amounts with a comma in would be parsed as if the
comma were a decimal i.e. £1,000 would be added to the running
total as £1.