### PR TITLE
Alter print layout for post-NOMIS cashbook screens

### DIFF
--- a/mtp_cashbook/assets-src/stylesheets/views/_credits.scss
+++ b/mtp_cashbook/assets-src/stylesheets/views/_credits.scss
@@ -209,6 +209,26 @@
       }
     }
 
+    .mtp-nomis-print-header {
+      border: 2px solid $text-colour;
+
+      img {
+        margin-left: 35px;
+        margin-top: 18px;
+        float: left;
+      }
+
+      div.mtp-nomis-warning {
+        padding-left: 100px;
+        padding-bottom: 1em;
+
+        h2.heading-medium {
+          text-align: left;
+          margin-bottom: 0;
+        }
+      }
+    }
+
     .print-box {
       text-align: center;
     }
@@ -223,15 +243,6 @@
       }
     }
 
-    .print-checkbox {
-      margin-left: 2em;
-      margin-bottom: 1em;
-      width: 20px;
-      height: 20px;
-      border: 2px solid #000;
-      display: inline-block;
-    }
-
     h2.print-only {
       padding-top: 1em;
     }
@@ -241,17 +252,7 @@
     }
 
     .mtp-floating-header {
-      margin-top: 0;
-      border-bottom: 0;
-
-      p span {
-        &.label {
-          font-size: em(10);
-          width: 7em;
-        }
-
-        margin-bottom: 1em;
-      }
+      display: none;
     }
 
     .mtp-batch {

--- a/mtp_cashbook/templates/cashbook/new_credits.html
+++ b/mtp_cashbook/templates/cashbook/new_credits.html
@@ -3,6 +3,7 @@
 {% load currency %}
 {% load mtp_common %}
 {% load credits %}
+{% load staticfiles %}
 
 {% block page_title %}{% trans 'New credits - Digital cashbook' %}{% endblock %}
 
@@ -32,12 +33,6 @@
         <h2 class="heading-small">
           {% trans "CONFIDENTIAL: dispose of securely" %}
         </h2>
-        <p>
-          {% blocktrans trimmed with total=total|currency %}
-          1-{{ new_credits }} credits <br />
-          <strong>Total: &pound;{{total}}</strong>
-          {% endblocktrans %}
-        </p>
       </div>
 
       <div class="mtp-batch">
@@ -69,9 +64,17 @@
           </div>
         </div>
 
-        <h2 class="print-only heading-xlarge">
-          {% trans 'Do NOT enter these credits into NOMIS yourself.' %}
-        </h2>
+        <div class="mtp-nomis-print-header print-only">
+          <img src="{% static 'images/icon-important.png' %}"/>
+          <div class="mtp-nomis-warning">
+            <h2 class="heading-medium">
+              {% trans 'You don’t have to manually enter credits into NOMIS any more' %}
+            </h2>
+            <div>
+              {% trans 'Now when you ’confirm’ credits, they’ll be sent digitally to NOMIS' %}
+            </div>
+          </div>
+        </div>
 
         <table>
           <thead>
@@ -106,7 +109,7 @@
               {% if pre_approval_required %}
                 <th>{% trans 'Security' %}</th>
               {% endif %}
-              <th class="check"><span id="id_credits-label">{% trans 'Select' %}</span></th>
+              <th class="check print-hidden"><span id="id_credits-label">{% trans 'Select' %}</span></th>
             </tr>
           </thead>
 
@@ -144,8 +147,7 @@
                     {% endif %}
                   </td>
                 {% endif %}
-                <td class="check">
-                  <div class="print-only print-checkbox"></div>
+                <td class="check print-hidden">
                   <input
                     type="checkbox"
                     name="{{ form.credits.html_name }}"


### PR DESCRIPTION
Removes the 'select' boxes from the printout as they should not be
using it for any processing anymore.