### PR TITLE
Pass credits as body params to spooler job

### DIFF
--- a/mtp_cashbook/apps/cashbook/tasks.py
+++ b/mtp_cashbook/apps/cashbook/tasks.py
@@ -11,7 +11,7 @@ from requests.exceptions import HTTPError
 logger = logging.getLogger('mtp')
 
 
-@spoolable()
+@spoolable(body_params=('credits',))
 def credit_selected_credits_to_nomis(user, session, selected_credit_ids, credits):
     for credit_id in selected_credit_ids:
         if credit_id in credits:


### PR DESCRIPTION
We have seen some instances of arguments being too large for this
job.