### PR TITLE
Maintain a thread local requests session for connections to NOMIS

### DIFF
--- a/mtp_cashbook/apps/cashbook/forms.py
+++ b/mtp_cashbook/apps/cashbook/forms.py
@@ -62,7 +62,7 @@ class ProcessNewCreditsForm(GARequestErrorReportingMixin, forms.Form):
 
         self.session.post('credits/batches/', json={'credits': credit_ids})
         credit_selected_credits_to_nomis(
-            user=self.request.user, session=self.request.session,
+            user=self.request.user, user_session=self.request.session,
             selected_credit_ids=credit_ids, credits=credits
         )
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=6.1,<6.2
+money-to-prisoners-common[testing]>=6.2,<6.3

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=6.1,<6.2
+money-to-prisoners-common[monitoring]>=6.2,<6.3
 
 uWSGI==2.0.15


### PR DESCRIPTION
This is due to SSL handshake failures when the NOMIS API is under
heavy load - using a session and a connection pool to reuse connections
avoids some of this overhead.