### PR TITLE
Clear entered disbursement data if coming from start page

### DIFF
--- a/mtp_cashbook/apps/disbursements/views.py
+++ b/mtp_cashbook/apps/disbursements/views.py
@@ -700,7 +700,7 @@ class UpdateRemittanceDescriptionView(BaseEditFormView, RemittanceDescriptionVie
 
 class StartView(BaseView):
     url_name = 'start'
-    get_success_url = reverse_lazy('disbursements:%s' % SendingMethodView.url_name)
+    get_success_url = reverse_lazy('disbursements:clear_disbursement')
 
     def get_context_data(self, **kwargs):
         kwargs['confirmed_disbursement_count'] = sum(


### PR DESCRIPTION
If the user enters the create disbursement flow from the start page,
any previously entered form data from any incomplete disbursement
should be cleared.