### PR TITLE
Restore lowercase name checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,3 @@ browsersync_ui_port = 3031
 exclude = .git/,node_modules/,venv/
 max-complexity = 12
 max-line-length = 120
-
-# remove after pep8-naming is fixed
-extend-ignore = N803,N812


### PR DESCRIPTION
…because `pep8-naming` has been fixed