### PR TITLE
Nomis Elite2 API

### DIFF
--- a/mtp_cashbook/apps/cashbook/tests/__init__.py
+++ b/mtp_cashbook/apps/cashbook/tests/__init__.py
@@ -2,7 +2,7 @@ from unittest import mock
 from urllib.parse import urljoin
 
 from django.conf import settings
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 from django.urls import reverse
 from django.utils.functional import cached_property
 from mtp_common.auth.test_utils import generate_tokens
@@ -92,23 +92,6 @@ class MTPBaseTestCase(SimpleTestCase):
 
 def api_url(path):
     return urljoin(settings.API_URL, path)
-
-
-def nomis_url(path):
-    return urljoin(settings.NOMIS_API_BASE_URL, path)
-
-
-override_nomis_settings = override_settings(
-    NOMIS_API_BASE_URL='https://nomis.local/',
-    NOMIS_API_CLIENT_TOKEN='hello',
-    NOMIS_API_PRIVATE_KEY=(
-        '-----BEGIN EC PRIVATE KEY-----\n'
-        'MHcCAQEEIOhhs3RXk8dU/YQE3j2s6u97mNxAM9s+13S+cF9YVgluoAoGCCqGSM49\n'
-        'AwEHoUQDQgAE6l49nl7NN6k6lJBfGPf4QMeHNuER/o+fLlt8mCR5P7LXBfMG6Uj6\n'
-        'TUeoge9H2N/cCafyhCKdFRdQF9lYB2jB+A==\n'
-        '-----END EC PRIVATE KEY-----\n'
-    ),  # this key is just for tests, doesn't do anything
-)
 
 
 def wrap_response_data(*args):

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -264,6 +264,10 @@ NOMIS_API_BASE_URL = os.environ.get('NOMIS_API_BASE_URL', '')
 NOMIS_API_CLIENT_TOKEN = os.environ.get('NOMIS_API_CLIENT_TOKEN', '')
 NOMIS_API_PRIVATE_KEY = os.environ.get('NOMIS_API_PRIVATE_KEY', '').encode('utf8').decode('unicode_escape')
 
+NOMIS_ELITE_CLIENT_ID = os.environ.get('NOMIS_ELITE_CLIENT_ID', '')
+NOMIS_ELITE_CLIENT_SECRET = os.environ.get('NOMIS_ELITE_CLIENT_SECRET', '')
+NOMIS_ELITE_BASE_URL = os.environ.get('NOMIS_ELITE_BASE_URL', '')
+
 TOKEN_RETRIEVAL_USERNAME = os.environ.get('TOKEN_RETRIEVAL_USERNAME', '_token_retrieval')
 TOKEN_RETRIEVAL_PASSWORD = os.environ.get('TOKEN_RETRIEVAL_PASSWORD', '_token_retrieval')
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=9.13,<9.14
+money-to-prisoners-common[testing]>=9.14,<9.15

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=9.13,<9.14
+money-to-prisoners-common[monitoring]>=9.14,<9.15
 
 uWSGI==2.0.18


### PR DESCRIPTION
This adds support for the new NOMIS Elite2 auth and API.
It mainly refactors the tests to mock the methods of the nomis library instead of mocking the nomis responses; this way we don't leak any internal nomis logic.