### PR TITLE
Remove template-deploy artefacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,18 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
+          name: Log into ECR
+          command: |
+            source /tmp/mtp-env.sh
+            $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
+      - run:
           name: Build docker image
           command: |
             source /tmp/mtp-env.sh
+            docker pull ${registry}:base-web
+            docker tag ${registry}:base-web base-web
             docker build \
-              --pull --force-rm \
+              --force-rm \
               --build-arg APP_GIT_COMMIT=${CIRCLE_SHA1} \
               --build-arg APP_GIT_BRANCH=${CIRCLE_BRANCH} \
               --build-arg APP_BUILD_TAG=${tag} \
@@ -49,7 +56,6 @@ jobs:
           name: Push docker image
           command: |
             source /tmp/mtp-env.sh
-            $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
             echo "Pushing ${tag} to ECR"
             docker tag ${tag} ${registry}:${tag}
             docker push ${registry}:${tag}
@@ -58,6 +64,10 @@ jobs:
               docker tag ${tag} ${registry}:${app}
               docker push ${registry}:${app}
             fi
+      - run:
+          name: Log out of ECR
+          command: |
+            source /tmp/mtp-env.sh
             docker logout ${ECR_ENDPOINT}
       - run:
           name: Deploy to test

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ministryofjustice/prisoner-money

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Money to Prisoners Cashbook
+# Digital Cashbook
 
-
-The Cashbook UI for the Money to Prisoners Project
-
+Business hub staff facing site for Prisoner Money suite of apps.
 
 ## Running locally
 
@@ -13,34 +11,32 @@ Please call this `venv` and make sure it's in the root folder of this applicatio
 In order to run the application locally, it is necessary to have the API running.
 Please refer to the [money-to-prisoners-api](https://github.com/ministryofjustice/money-to-prisoners-api/) repository.
 
-Once the API is running locally, run
+Once the API has started locally, run
 
 ```
+./run.py serve
+# or
 ./run.py start
 ```
 
-This will build everything (which will initially take a while) and run
-the local server at [http://localhost:8001](http://localhost:8001).
+This will build everything and run the local server at [http://localhost:8001](http://localhost:8001).
+
+You should be able to login using following credentials: `test-prison-1` or `test-prison-2`
 
 ### Alternative: Docker
 
 In order to run a server that's exactly similar to the production machines,
-you need to have [Docker](https://www.docker.com/docker-toolbox) installed. Run
+you need to have [Docker](https://www.docker.com/products/developer-tools) installed. Run
 
 ```
 ./run.py local_docker
 ```
 
-and you should eventually be able to connect to the local server.
-
-### Log in to the application
-
-You should be able to log into the cash book app using following credentials:
-
-- *test-prison-1 / test-prison-1* for Prison 1
-- *test-prison-2 / test-prison-2* for Prison 2
+and you should be able to connect to the local server.
 
 ## Developing
+
+[![CircleCI](https://circleci.com/gh/ministryofjustice/money-to-prisoners-cashbook.svg?style=svg)](https://circleci.com/gh/ministryofjustice/money-to-prisoners-cashbook)
 
 With the `./run.py` command, you can run a browser-sync server, and get the assets
 to automatically recompile when changes are made, run `./run.py serve` instead of
@@ -63,9 +59,11 @@ python_dependencies --common-path [path]
 
 Update translation files with `./run.py make_messages` – you need to do this every time any translatable text is updated.
 
-Pull updates from Transifex with ``./run.py translations --pull``. You'll need to update translation files afterwards and manually check that the merges occurred correctly.
+Pull updates from Transifex with `./run.py translations --pull`.
+You'll need to update translation files afterwards and manually check that the merges occurred correctly.
 
-Push latest English to Transifex with ``./run.py translations --push``. NB: you should pull updates before pushing to merge correctly.
+Push latest English to Transifex with `./run.py translations --push`.
+NB: you should pull updates before pushing to merge correctly.
 
 ## Deploying
 

--- a/mtp_cashbook/apps/cashbook/metrics.py
+++ b/mtp_cashbook/apps/cashbook/metrics.py
@@ -1,0 +1,7 @@
+from django.apps import apps
+from prometheus_client import Summary
+
+credited_summary = Summary('mtp_cashbook_credited', 'Credits credited')
+
+app = apps.get_app_config('metrics')
+app.register_collector(credited_summary)

--- a/mtp_cashbook/apps/cashbook/tasks.py
+++ b/mtp_cashbook/apps/cashbook/tasks.py
@@ -1,5 +1,6 @@
 import logging
 from threading import local
+from urllib.parse import urljoin
 
 from django.conf import settings
 from django.utils.translation import gettext as _
@@ -75,8 +76,8 @@ def credit_individual_credit_to_nomis(user, user_session, credit_id, credit):
                 'ref_number': credit.get('short_ref_number'),
                 'received_at': credit['received_at'],
                 'prisoner_name': credit.get('intended_recipient'),
-                'help_url': settings.CITIZEN_HELP_PAGE_URL,
-                'feedback_url': settings.CITIZEN_CONTACT_PAGE_URL,
+                'help_url': urljoin(settings.SEND_MONEY_URL, '/help/'),
+                'feedback_url': urljoin(settings.SEND_MONEY_URL, '/contact-us/'),
                 'site_url': settings.START_PAGE_URL,
             },
             html_template='cashbook/email/credited-confirmation.html',

--- a/mtp_cashbook/apps/cashbook/tasks.py
+++ b/mtp_cashbook/apps/cashbook/tasks.py
@@ -11,6 +11,8 @@ from mtp_common.tasks import send_email
 import requests
 from requests.exceptions import HTTPError, RequestException
 
+from cashbook import metrics
+
 logger = logging.getLogger('mtp')
 
 thread_local = local()
@@ -19,12 +21,14 @@ thread_local.nomis_session = requests.Session()
 
 @spoolable(body_params=('user', 'user_session', 'selected_credit_ids', 'credits',))
 def credit_selected_credits_to_nomis(*, user, user_session, selected_credit_ids, credits):
+    credited = 0
     for credit_id in selected_credit_ids:
         if credit_id in credits:
-            credit_individual_credit_to_nomis(
-                user, user_session, credit_id, credits[credit_id])
+            credit_individual_credit_to_nomis(user, user_session, credit_id, credits[credit_id])
+            credited += 1
         else:
             logger.warning('Credit %s is no longer available' % credit_id)
+    metrics.credited_summary.observe(credited)
 
 
 @spoolable()

--- a/mtp_cashbook/apps/disbursements/forms.py
+++ b/mtp_cashbook/apps/disbursements/forms.py
@@ -27,6 +27,8 @@ from mtp_common.bank_accounts import (
 from mtp_common.auth.exceptions import HttpNotFoundError, Forbidden
 from requests.exceptions import RequestException
 
+from disbursements import metrics
+
 logger = logging.getLogger('mtp')
 
 SENDING_METHOD = Choices(
@@ -424,6 +426,7 @@ class RejectDisbursementForm(GARequestErrorReportingMixin, forms.Form):
             'disbursements/actions/reject/',
             json={'disbursement_ids': [disbursement_id]}
         )
+        metrics.rejected_counter.inc()
         reason = self.cleaned_data['reason']
         if reason:
             reasons = [{

--- a/mtp_cashbook/apps/disbursements/metrics.py
+++ b/mtp_cashbook/apps/disbursements/metrics.py
@@ -1,0 +1,11 @@
+from django.apps import apps
+from prometheus_client import Counter
+
+entered_counter = Counter('mtp_cashbook_entered', 'Disbursements entered')
+confirmed_counter = Counter('mtp_cashbook_confirmed', 'Disbursements confirmed')
+rejected_counter = Counter('mtp_cashbook_rejected', 'Disbursements rejected')
+
+app = apps.get_app_config('metrics')
+app.register_collector(entered_counter)
+app.register_collector(confirmed_counter)
+app.register_collector(rejected_counter)

--- a/mtp_cashbook/apps/disbursements/views.py
+++ b/mtp_cashbook/apps/disbursements/views.py
@@ -18,7 +18,7 @@ from mtp_common import nomis
 from requests.exceptions import HTTPError, RequestException
 
 from cashbook.templatetags.currency import currency
-from disbursements import forms as disbursement_forms
+from disbursements import forms as disbursement_forms, metrics
 from disbursements.utils import get_disbursement_viability, find_addresses
 from feedback.views import GetHelpView, GetHelpSuccessView
 
@@ -391,6 +391,7 @@ class CreatedView(BasePagedView):
             del disbursement_data['remittance']
         try:
             self.api_session.post('/disbursements/', json=disbursement_data)
+            metrics.entered_counter.inc()
         except RequestException:
             logger.exception('Failed to create disbursement')
             return redirect('%s?e=connection' % self.previous_view.url())
@@ -546,6 +547,7 @@ class PendingDetailView(BaseConfirmationView):
                 'disbursements/actions/confirm/',
                 json=[update]
             )
+            metrics.confirmed_counter.inc()
             return redirect(ConfirmedView.url() + url_suffix)
 
         self.api_session.post(

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -218,26 +218,9 @@ TEST_RUNNER = 'mtp_common.test_utils.runner.TestRunner'
 # authentication
 SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
 MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
-
 AUTHENTICATION_BACKENDS = (
     'mtp_common.auth.backends.MojBackend',
 )
-
-
-def find_api_url():
-    import socket
-    import subprocess
-
-    api_port = int(os.environ.get('API_PORT', '8000'))
-    try:
-        host_machine_ip = subprocess.check_output(['docker-machine', 'ip', 'default'],
-                                                  stderr=subprocess.DEVNULL)
-        host_machine_ip = host_machine_ip.decode('ascii').strip()
-        with socket.socket() as sock:
-            sock.connect((host_machine_ip, api_port))
-    except (subprocess.CalledProcessError, OSError):
-        host_machine_ip = 'localhost'
-    return 'http://%s:%s' % (host_machine_ip, api_port)
 
 
 # control the time a session exists for; should match api's access token expiry
@@ -247,7 +230,7 @@ SESSION_SAVE_EVERY_REQUEST = True
 
 API_CLIENT_ID = 'cashbook'
 API_CLIENT_SECRET = os.environ.get('API_CLIENT_SECRET', 'cashbook')
-API_URL = os.environ.get('API_URL', find_api_url())
+API_URL = os.environ.get('API_URL', 'http://localhost:8000')
 
 LOGIN_URL = 'login'
 LOGIN_REDIRECT_URL = 'home'

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -1,9 +1,3 @@
-"""
-Django settings for mtp_cashbook project.
-
-For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.9/ref/settings/
-"""
 from functools import partial
 import os
 from os.path import abspath, dirname, join

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -8,6 +8,7 @@ from functools import partial
 import os
 from os.path import abspath, dirname, join
 import sys
+from urllib.parse import urljoin
 
 BASE_DIR = dirname(dirname(abspath(__file__)))
 sys.path.insert(0, os.path.join(BASE_DIR, 'apps'))
@@ -25,17 +26,29 @@ DEBUG = True
 SECRET_KEY = 'CHANGE_ME'
 ALLOWED_HOSTS = []
 
-CITIZEN_HELP_PAGE_URL = os.environ.get(
-    'CITIZEN_HELP_PAGE_URL',
-    'https://send-money-to-prisoner.service.gov.uk/help/'
-)
-CITIZEN_CONTACT_PAGE_URL = os.environ.get(
-    'CITIZEN_CONTACT_PAGE_URL',
-    'https://send-money-to-prisoner.service.gov.uk/contact-us/'
-)
 START_PAGE_URL = os.environ.get('START_PAGE_URL', 'https://www.gov.uk/send-prisoner-money')
-SITE_URL = os.environ.get('SITE_URL', 'http://localhost:8001')
-NOMS_OPS_URL = os.environ.get('NOMS_OPS_URL', 'http://localhost:8003/')
+CASHBOOK_URL = (
+    f'https://{os.environ["PUBLIC_CASHBOOK_HOST"]}'
+    if os.environ.get('PUBLIC_CASHBOOK_HOST')
+    else 'http://localhost:8001'
+)
+BANK_ADMIN_URL = (
+    f'https://{os.environ["PUBLIC_BANK_ADMIN_HOST"]}'
+    if os.environ.get('PUBLIC_BANK_ADMIN_HOST')
+    else 'http://localhost:8002'
+)
+NOMS_OPS_URL = (
+    f'https://{os.environ["PUBLIC_NOMS_OPS_HOST"]}'
+    if os.environ.get('PUBLIC_NOMS_OPS_HOST')
+    else 'http://localhost:8003'
+)
+SEND_MONEY_URL = (
+    f'https://{os.environ["PUBLIC_SEND_MONEY_HOST"]}'
+    if os.environ.get('PUBLIC_SEND_MONEY_HOST')
+    else 'http://localhost:8004'
+)
+SITE_URL = CASHBOOK_URL
+
 
 # Application definition
 INSTALLED_APPS = (
@@ -117,6 +130,7 @@ STATICFILES_DIRS = [
     get_project_dir('assets'),
     get_project_dir('assets-static'),
 ]
+PUBLIC_STATIC_URL = urljoin(SEND_MONEY_URL, STATIC_URL)
 
 TEMPLATES = [
     {

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = (
 PROJECT_APPS = (
     'anymail',
     'mtp_common',
+    'mtp_common.metrics',
     'widget_tweaks',
     'cashbook',
     'zendesk_tickets',
@@ -81,6 +82,9 @@ MIDDLEWARE = (
 
 HEALTHCHECKS = []
 AUTODISCOVER_HEALTHCHECKS = True
+
+METRICS_USER = os.environ.get('METRICS_USER', 'prom')
+METRICS_PASS = os.environ.get('METRICS_PASS', 'prom')
 
 # security tightening
 # some overridden in prod/docker settings where SSL is ensured

--- a/mtp_cashbook/urls.py
+++ b/mtp_cashbook/urls.py
@@ -9,6 +9,7 @@ from django.views.generic.base import RedirectView, TemplateView
 from django.views.i18n import JavaScriptCatalog
 from moj_irat.views import HealthcheckView, PingJsonView
 from mtp_common.auth import api_client
+from mtp_common.metrics.views import metrics_view
 
 
 class LandingView(TemplateView):
@@ -48,6 +49,7 @@ urlpatterns += [
         version_number_key='APP_BUILD_TAG',
     ), name='ping_json'),
     url(r'^healthcheck.json$', HealthcheckView.as_view(), name='healthcheck_json'),
+    url(r'^metrics.txt$', metrics_view, name='prometheus_metrics'),
 
     url(r'^favicon.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'images/favicon.ico', permanent=True)),
     url(r'^robots.txt$', lambda request: HttpResponse('User-agent: *\nDisallow: /', content_type='text/plain')),

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
 # Place development dependencies here
 -r base.txt
 
-money-to-prisoners-common[testing]>=9.14,<9.15
+money-to-prisoners-common[testing]>=9.15,<9.16

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,6 @@
 # Place docker dependencies here
 -r base.txt
 
-money-to-prisoners-common[monitoring]>=9.14,<9.15
+money-to-prisoners-common[monitoring]>=9.15,<9.16
 
 uWSGI==2.0.18


### PR DESCRIPTION
- As apps are now able to discover each other, many environment variables are now redundant so they can be removed
- Apps now use base Docker images built by this repository (pulling from ECR or building locally) – this speeds up builds and ensures they have the same base OS
- Add prometheus service monitors for all apps
- Depends on [mtp-deploy#282](https://github.com/ministryofjustice/money-to-prisoners-deploy/pull/282)