### PR TITLE
Mtp 1591 cashbook policy change banner Version 2

### DIFF
--- a/mtp_cashbook/apps/cashbook/tests/test_misc_views.py
+++ b/mtp_cashbook/apps/cashbook/tests/test_misc_views.py
@@ -75,3 +75,14 @@ class MLBriefingTestCase(MTPBaseTestCase):
             follow=True,
         )
         self.assertOnPage(response, 'ml-briefing')
+
+
+class PolicyUpdateTestCase(MTPBaseTestCase):
+    def test_requires_login(self):
+        response = self.client.get(reverse('home'), follow=True)
+        self.assertOnPage(response, 'login')
+
+    def test_displays_policy_update_page(self):
+        self.login()
+        response = self.client.get(reverse('policy-change'), follow=True)
+        self.assertOnPage(response, 'policy-change-warning')

--- a/mtp_cashbook/misc_views.py
+++ b/mtp_cashbook/misc_views.py
@@ -92,3 +92,8 @@ class MLBriefingView(BaseView, TemplateView):
         if request.read_ml_briefing:
             return redirect(MLBriefingConfirmationView.success_url)
         return super().dispatch(request, **kwargs)
+
+
+class PolicyChangeInfo(BaseView, TemplateView):
+    title = _('How Nov 2nd policy changes will affect you')
+    template_name = 'policy-change-warning.html'

--- a/mtp_cashbook/templates/policy-change-warning-credits.html
+++ b/mtp_cashbook/templates/policy-change-warning-credits.html
@@ -2,14 +2,6 @@
 
 <div class="mtp-notification mtp-notification--info mtp-notification--open">
   <h2 class="mtp-notification__headline">
-    {% trans 'No more bank transfers' %}
+    <a href="{% url 'policy-change' %}">{% trans 'No more bank transfers' %}</a>
   </h2>
-  <div class="mtp-notification__message">
-
-    <p>{% trans 'A policy change from November 2nd means that senders have to ‘Send money to someone in prison’ using a debit card.' %}</p>
-    <p>{% trans 'They will no longer be able to send money by bank transfer or send in cash, cheques or postal orders by post.' %}</p>
-    <p>{% trans 'If they don’t have a bank account, we’re encouraging them to set one up. If they can’t use the service, they can apply to the governor for an ‘exemption’.' %}</p>
-    <p>{% trans 'You may see a temporary rise in complaints because of these changes.' %}</p>
-
-  </div>
 </div>

--- a/mtp_cashbook/templates/policy-change-warning-disbursements.html
+++ b/mtp_cashbook/templates/policy-change-warning-disbursements.html
@@ -1,42 +1,7 @@
 {% load i18n %}
-{% load static %}
-
-{% static 'downloads/apply-to-send-out-more-than-50.pdf' as form_link %}
 
 <div class="mtp-notification mtp-notification--info mtp-notification--open">
   <h2 class="mtp-notification__headline">
-    {% trans 'How the cap on disbursements works' %}
+    <a href="{% url 'policy-change' %}">{% trans 'How the cap on disbursements works' %}</a>
   </h2>
-  <div class="mtp-notification__message">
-
-    <h3><strong>{% trans 'What is the disbursements cap?' %}</strong></h3>
-    <p>{% trans 'A policy change from November 2nd means only £50 a week can be sent out to each person.' %}</p>
-    <p>{% trans 'Example: They can send up to £250 a week, if it’s to 5 different people.' %}</p>
-
-    <h3><strong>{% trans 'If they want to send out more' %}</strong></h3>
-    <p>
-      {% blocktrans %}
-        A resident must apply for approval from the governor if they want to send more than £50 per person per week. In exceptional circumstances, this might be granted. It must be applied for each time by filling in a <a href="{{ form_link }}">form</a> which is attached to their disbursement before handing in.
-      {% endblocktrans %}
-    </p>
-
-    <h3><strong>{% trans 'What you need to do' %}</strong></h3>
-    <p>{% trans 'If the resident’s application is approved, make the disbursement. If it is not approved, send the application form back with a reason why.' %}</p>
-
-    <h3><strong>{% trans 'Exceptional circumstances could be:' %}</strong></h3>
-    <ul class="list list-bullet">
-      <li>{% trans 'paying off debts if you have no external bank account' %}</li>
-      <li>{% trans 'sending financial support to family' %}</li>
-      <li>{% trans 'paying for a legitimate service, e.g. legal fees, dentistry' %}</li>
-      <li>{% trans 'operating a business, if unconvicted' %}</li>
-      <li>{% trans 'transferring your money from prison to a new or existing bank account' %}</li>
-    </ul>
-
-    <p>
-      {% blocktrans trimmed %}
-        This is a copy of the new <a href="{{ form_link }}">‘Apply to send more than £50’ disbursement form</a>
-      {% endblocktrans %}
-    </p>
-
-  </div>
 </div>

--- a/mtp_cashbook/templates/policy-change-warning-landing.html
+++ b/mtp_cashbook/templates/policy-change-warning-landing.html
@@ -8,11 +8,11 @@
 
     <h3><strong>{% trans 'Credits' %}</strong></h3>
     <p>{% trans 'Senders will no longer be able to send money by bank transfer.' %}</p>
-    <p><a href="{% url 'new-credits' %}">{% trans 'More details' %}</a></p>
 
     <h3><strong>{% trans 'Disbursements' %}</strong></h3>
     <p>{% trans 'There will be a cap on how much money can be sent out of prison.' %}</p>
     <p>{% trans 'The cap will be a maximum of £50 a week sent out to each person.' %}</p>
-    <p><a href="{% url 'disbursements:start' %}">{% trans 'More details' %}</a></p>
+
+    <p><a href="{% url 'policy-change' %}">{% trans 'More details about Credit and Disbursement changes' %}</a></p>
   </div>
 </div>

--- a/mtp_cashbook/templates/policy-change-warning.html
+++ b/mtp_cashbook/templates/policy-change-warning.html
@@ -1,0 +1,61 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load mtp_common %}
+{% load static %}
+
+{% block inner_content %}
+
+  {% static 'downloads/apply-to-send-out-more-than-50.pdf' as form_link %}
+
+  {% notifications_box request 'cashbook_dashboard' 'cashbook_all' %}
+
+  {% include 'mtp_common/includes/message_box.html' %}
+
+  <!--[policy-change-warning]-->
+  <header>
+    <h1 class="heading-xlarge">{% trans 'How Nov 2nd policy changes will affect you' %}</h1>
+  </header>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h2 class="heading-large">{% trans 'No more bank transfers' %}</h2>
+
+      <p>{% trans 'A policy change from November 2nd means that senders have to ‘Send money to someone in prison’ using a debit card.' %}</p>
+      <p>{% trans 'They will no longer be able to send money by bank transfer or send in cash, cheques or postal orders by post.' %}</p>
+      <p>{% trans 'If they don’t have a bank account, we’re encouraging them to set one up. If they can’t use the service, they can apply to the governor for an ‘exemption’.' %}</p>
+      <p>{% trans 'You may see a temporary rise in complaints because of these changes.' %}</p>
+
+      <h2 class="heading-large">{% trans 'What is the disbursements cap?' %}</strong></h3>
+      <p>{% trans 'A policy change from November 2nd means only £50 a week can be sent out to each person.' %}</p>
+      <p>{% trans 'Example: They can send up to £250 a week, if it’s to 5 different people.' %}</p>
+
+      <h3><strong>{% trans 'If they want to send out more' %}</strong></h3>
+      <p>
+        {% blocktrans %}
+          A resident must apply for approval from the governor if they want to send more than £50 per person per week. In exceptional circumstances, this might be granted. It must be applied for each time by filling in a <a href="{{ form_link }}">form</a> which is attached to their disbursement before handing in.
+        {% endblocktrans %}
+      </p>
+
+      <h3><strong>{% trans 'What you need to do' %}</strong></h3>
+      <p>{% trans 'If the resident’s application is approved, make the disbursement. If it is not approved, send the application form back with a reason why.' %}</p>
+
+      <h3><strong>{% trans 'Exceptional circumstances could be:' %}</strong></h3>
+      <ul class="list list-bullet">
+        <li>{% trans 'paying off debts if you have no external bank account' %}</li>
+        <li>{% trans 'sending financial support to family' %}</li>
+        <li>{% trans 'paying for a legitimate service, e.g. legal fees, dentistry' %}</li>
+        <li>{% trans 'operating a business, if unconvicted' %}</li>
+        <li>{% trans 'transferring your money from prison to a new or existing bank account' %}</li>
+      </ul>
+
+      <p>
+        {% blocktrans trimmed %}
+          This is a copy of the new <a href="{{ form_link }}">‘Apply to send more than £50’ disbursement form</a>
+        {% endblocktrans %}
+      </p>
+
+
+    </div>
+  </div>
+{% endblock %}

--- a/mtp_cashbook/urls.py
+++ b/mtp_cashbook/urls.py
@@ -17,6 +17,7 @@ urlpatterns = i18n_patterns(
 
     url(r'^ml-briefing/$', misc_views.MLBriefingConfirmationView.as_view(), name='ml-briefing-confirmation'),
     url(r'^ml-briefing/read/$', misc_views.MLBriefingView.as_view(), name='ml-briefing'),
+    url(r'^policy-change/$', misc_views.PolicyChangeInfo.as_view(), name='policy-change'),
 
     url(r'^', include('cashbook.urls')),
     url(r'^disbursements/', include('disbursements.urls', namespace='disbursements')),


### PR DESCRIPTION
This is the changed warning for upcoming policy changes, linking to a page with full details on changes rather than including longer copy on credit/disbursement changes in pages regularly used for work purposes. It avoids the need to have dismiss-able notifications and having to manage state of a user dismissing the notice etc.

Landing Page
![image](https://user-images.githubusercontent.com/436713/95475084-c8d69480-097d-11eb-8eb4-45d3d6a97d2c.png)

Credits page
![image](https://user-images.githubusercontent.com/436713/95475134-d2f89300-097d-11eb-8ed1-9c801634ec86.png)

Disbursements
![image](https://user-images.githubusercontent.com/436713/95475192-dee45500-097d-11eb-8428-c9991b408109.png)

Detail page
![image](https://user-images.githubusercontent.com/436713/95475262-ef94cb00-097d-11eb-8a27-4e96b6bfb660.png)
