### PR TITLE
Use correct payment ref field from mtp-api's credit response

### DIFF
--- a/mtp_cashbook/apps/cashbook/tasks.py
+++ b/mtp_cashbook/apps/cashbook/tasks.py
@@ -85,7 +85,7 @@ def credit_individual_credit_to_nomis(user, user_session, credit_id, credit):
             _('Send money to someone in prison: the prisoner’s account has been credited'),
             context={
                 'amount': credit['amount'],
-                'ref_number': credit.get('short_ref_number'),
+                'ref_number': credit.get('short_payment_ref'),
                 'received_at': credit['received_at'],
                 'prisoner_name': credit.get('intended_recipient'),
                 'help_url': urljoin(settings.SEND_MONEY_URL, '/help/'),

--- a/mtp_cashbook/apps/cashbook/tests/test_views.py
+++ b/mtp_cashbook/apps/cashbook/tests/test_views.py
@@ -24,7 +24,7 @@ CREDIT_1 = {
     'amount': 5200,
     'sender_name': 'Fred Smith',
     'sender_email': 'fred.smith@mail.local',
-    'short_ref_number': '89AF76GH',
+    'short_payment_ref': '319900D4',
     'received_at': '2017-01-25T12:00:00Z',
     'owner': 100,
     'owner_name': 'Staff 1',
@@ -38,7 +38,7 @@ CREDIT_2 = {
     'amount': 4500,
     'sender_name': 'Fred Jones',
     'sender_email': 'fred.jones@mail.local',
-    'short_ref_number': '98KI32SA',
+    'short_payment_ref': 'BAAB65F6',
     'received_at': '2017-01-25T12:00:00Z',
     'owner': 100,
     'owner_name': 'Staff 1',
@@ -231,6 +231,10 @@ class NewCreditsViewTestCase(MTPBaseTestCase):
             self.assertTrue(
                 '£52.00' in mail.outbox[0].body and '£45.00' in mail.outbox[1].body or
                 '£52.00' in mail.outbox[1].body and '£45.00' in mail.outbox[0].body
+            )
+            self.assertTrue(
+                'BAAB65F6' in mail.outbox[0].body or
+                'BAAB65F6' in mail.outbox[1].body
             )
 
     @override_settings(

--- a/mtp_cashbook/templates/cashbook/email/credited-confirmation.html
+++ b/mtp_cashbook/templates/cashbook/email/credited-confirmation.html
@@ -6,9 +6,13 @@
   <p>{% trans 'Dear sender,' %}</p>
 
   <p>
-    {% blocktrans trimmed %}
-      The payment you made - confirmation number {{ ref_number }} - has now been credited to the prisoner’s account.
-    {% endblocktrans %}
+    {% if ref_number %}
+      {% blocktrans trimmed %}
+        The payment you made - confirmation number {{ ref_number }} - has now been credited to the prisoner’s account.
+      {% endblocktrans %}
+    {% else %}
+      {% trans 'The payment you made has now been credited to the prisoner’s account.' %}
+    {% endif %}
   </p>
 
   <table cellspacing="10" style="font-family: sans-serif;">

--- a/mtp_cashbook/templates/cashbook/email/credited-confirmation.txt
+++ b/mtp_cashbook/templates/cashbook/email/credited-confirmation.txt
@@ -4,9 +4,9 @@ GOV.UK - {% trans 'Send money to someone in prison' %}
 
 {% trans 'Dear sender,' %}
 
-{% blocktrans trimmed %}
+{% if ref_number %}{% blocktrans trimmed %}
 The payment you made - confirmation number {{ ref_number }} - has now been credited to the prisoner’s account.
-{% endblocktrans %}
+{% endblocktrans %}{% else %}{% trans 'The payment you made has now been credited to the prisoner’s account.' %}{% endif %}
 
 {% if prisoner_name %}{% trans 'Payment to:' %} {{ prisoner_name }}{% endif %}
 {% trans 'Amount paid:' %} £{{ amount|currency }}


### PR DESCRIPTION
`short_ref_number` was being used in place of `short_payment_ref` by mistake.

[MTP-1793](https://dsdmoj.atlassian.net/browse/MTP-1793)