### PR TITLE
MTP-1537: Removed dependencies already in mtp-common

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,15 +1,3 @@
 # Dependencies needed for all environments
 
 money-to-prisoners-common~=11.1.0
-
-Django>2.2,<2.3
-requests>=2.22,<3
-django-widget-tweaks>=1.4,<1.5
-transifex-client>=0.12
-django-anymail[mailgun]~=7.2
-django-extended-choices>=1.3,<2
-uWSGI==2.0.19.1
-
-django-form-error-reporting>=0.9
-django-moj-irat>=0.6
-django-zendesk-tickets>=0.14


### PR DESCRIPTION
Bumped `mtp-common` to ~`11.0.1`~ `11.1.0` and removed dependencies already requested there to reduce duplication.

⚠️ **NOTE**: This is a major version bump and `mtp-common` `11.x` includes other changes (e.g. GDS Design System) so merge/release this may require some coordination/[depends on this PR](https://github.com/ministryofjustice/money-to-prisoners-cashbook/pull/537).


See
---
Ticket: https://dsdmoj.atlassian.net/browse/MTP-1537