### PR TITLE
FAQ when user signed out

### DIFF
--- a/mtp_cashbook/misc_views.py
+++ b/mtp_cashbook/misc_views.py
@@ -120,3 +120,17 @@ class PolicyChangeInfo(BaseView, TemplateView):
             return ['policy-change-warning.html']
         else:
             return ['policy-change-info.html']
+
+
+class FAQView(TemplateView):
+    title = _('What do you need help with?')
+    template_name = 'faq.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context['contact_us_url'] = reverse_lazy('submit_ticket')
+        context['reset_password_url'] = reverse_lazy('reset_password')
+        context['sign_up_url'] = reverse_lazy('sign-up')
+
+        return context

--- a/mtp_cashbook/misc_views.py
+++ b/mtp_cashbook/misc_views.py
@@ -129,7 +129,7 @@ class FAQView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context['contact_us_url'] = reverse_lazy('submit_ticket')
+        context['breadcrumbs_back'] = reverse_lazy('home')
         context['reset_password_url'] = reverse_lazy('reset_password')
         context['sign_up_url'] = reverse_lazy('sign-up')
 

--- a/mtp_cashbook/templates/faq.html
+++ b/mtp_cashbook/templates/faq.html
@@ -1,0 +1,81 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block page_title %}{{ view.title }} – {{ block.super }}{% endblock %}
+
+{% block body_classes %}{{ block.super }} mtp-credits{% endblock %}
+
+{% block content %}
+  {{ block.super }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <a class="govuk-back-link" href="{% url 'home' %}">
+        {% trans 'Back' %}
+      </a>
+
+      <header>
+        <h1 class="govuk-heading-xl">{{ view.title }}</h1>
+      </header>
+
+
+      <h2 class="govuk-heading-m" id="faq-account-requested">
+        {% trans "I requested an account, but heard nothing" %}
+      </h2>
+
+      <p class="govuk-body">
+        {% blocktrans trimmed %}
+          Either remind your business hub manager to accept your request, or <a href="{{ sign_up_url }}" class="govuk-link">request an account</a> again.
+        {% endblocktrans %}
+      </p>
+
+
+      <h2 class="govuk-heading-m" id="faq-locked-out">
+        {% trans "I’m locked out" %}
+      </h2>
+
+      <p class="govuk-body">
+        {% blocktrans trimmed %}
+          If you mis-type your password too many times, you'll be locked out. Try again in about half an hour.
+        {% endblocktrans %}
+      </p>
+
+
+      <h2 class="govuk-heading-m" id="faq-may-have-account">
+        {% trans "I may already have an account" %}
+      </h2>
+
+      <p class="govuk-body">
+        {% blocktrans trimmed %}
+          Try <a href="{{ reset_password_url }}" class="govuk-link">resetting your password</a>. If you have an account, you'll get an email with a link. If not, <a href="{{ sign_up_url }}">request an account</a>.
+        {% endblocktrans %}
+      </p>
+
+
+      <h2 class="govuk-heading-m" id="faq-username">
+        {% trans "I've forgotten or need to change my username" %}
+      </h2>
+
+      <p class="govuk-body">
+        {% blocktrans trimmed %}
+            To change your username, <a href="{{ contact_us_url }}?message=My new username (usually your Quantum ID) is [please fill in]" class="govuk-link">contact us</a>.
+        {% endblocktrans %}
+      </p>
+
+
+      <h2 class="govuk-heading-m" id="faq-reset-password">
+        {% trans "Reset password isn’t working" %}
+      </h2>
+
+      <p class="govuk-body">
+        {% blocktrans trimmed %}
+          To reset your password, <a href="{{ contact_us_url }}?message=My new password is [please fill in]" class="govuk-link">contact us</a>.
+        {% endblocktrans %}
+      </p>
+
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/mtp_cashbook/templates/faq.html
+++ b/mtp_cashbook/templates/faq.html
@@ -11,10 +11,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <a class="govuk-back-link" href="{% url 'home' %}">
-        {% trans 'Back' %}
-      </a>
-
       <header>
         <h1 class="govuk-heading-xl">{{ view.title }}</h1>
       </header>
@@ -24,9 +20,9 @@
         {% trans "I requested an account, but heard nothing" %}
       </h2>
 
-      <p class="govuk-body">
+      <p>
         {% blocktrans trimmed %}
-          Either remind your business hub manager to accept your request, or <a href="{{ sign_up_url }}" class="govuk-link">request an account</a> again.
+          Either remind your business hub manager to accept your request, or <a href="{{ sign_up_url }}">request an account</a> again.
         {% endblocktrans %}
       </p>
 
@@ -35,9 +31,12 @@
         {% trans "I’m locked out" %}
       </h2>
 
-      <p class="govuk-body">
+      <p>
         {% blocktrans trimmed %}
-          If you mis-type your password too many times, you'll be locked out. Try again in about half an hour.
+          If you mis-type your password too many times, you'll be locked out.
+        {% endblocktrans %}
+        {% blocktrans trimmed %}
+          Try again in about half an hour.
         {% endblocktrans %}
       </p>
 
@@ -46,9 +45,15 @@
         {% trans "I may already have an account" %}
       </h2>
 
-      <p class="govuk-body">
+      <p>
         {% blocktrans trimmed %}
-          Try <a href="{{ reset_password_url }}" class="govuk-link">resetting your password</a>. If you have an account, you'll get an email with a link. If not, <a href="{{ sign_up_url }}">request an account</a>.
+          Try <a href="{{ reset_password_url }}">resetting your password</a>.
+        {% endblocktrans %}
+        {% blocktrans trimmed %}
+          If you have an account, you'll get an email with a link.
+        {% endblocktrans %}
+        {% blocktrans trimmed %}
+          If not, <a href="{{ sign_up_url }}">request an account</a>.
         {% endblocktrans %}
       </p>
 
@@ -57,9 +62,10 @@
         {% trans "I've forgotten or need to change my username" %}
       </h2>
 
-      <p class="govuk-body">
+      <p>
+        {% url 'submit_ticket' as contact_us_url %}
         {% blocktrans trimmed %}
-            To change your username, <a href="{{ contact_us_url }}?message=My new username (usually your Quantum ID) is [please fill in]" class="govuk-link">contact us</a>.
+            To change your username, <a href="{{ contact_us_url }}?message=My%20new%20username%20%28usually%20your%20Quantum%20ID%29%20is%20%5Bplease%20fill%20in%5D">contact us</a>.
         {% endblocktrans %}
       </p>
 
@@ -68,9 +74,10 @@
         {% trans "Reset password isn’t working" %}
       </h2>
 
-      <p class="govuk-body">
+      <p>
+        {% url 'submit_ticket' as contact_us_url %}
         {% blocktrans trimmed %}
-          To reset your password, <a href="{{ contact_us_url }}?message=My new password is [please fill in]" class="govuk-link">contact us</a>.
+          To reset your password, <a href="{{ contact_us_url }}?message=I%20need%20help%20resetting%20my%20password.%20My%20username%20is%20%5Bplease%20fill%20in%5D.">contact us</a>.
         {% endblocktrans %}
       </p>
 

--- a/mtp_cashbook/templates/govuk-frontend/components/footer.html
+++ b/mtp_cashbook/templates/govuk-frontend/components/footer.html
@@ -45,8 +45,12 @@
   </h2>
   <ul class="govuk-footer__inline-list">
     <li class="govuk-footer__inline-list-item">
-      {% url 'submit_ticket' as submit_ticket_fallback %}
-      <a class="govuk-footer__link" href="{{ request.proposition_app.help_url|default:submit_ticket_fallback }}">
+      {% if request.user.is_authenticated %}
+        {% url 'submit_ticket' as get_help_fallback %}
+      {% else %}
+        {% url 'faq' as get_help_fallback %}
+      {% endif %}
+      <a class="govuk-footer__link" href="{{ request.proposition_app.help_url|default:get_help_fallback }}">
         {% trans 'Get help' %}
       </a>
     </li>

--- a/mtp_cashbook/templates/mtp_auth/login.html
+++ b/mtp_cashbook/templates/mtp_auth/login.html
@@ -83,9 +83,9 @@
     <br />
 
     <p>
-      {% url 'submit_ticket' as get_help_link %}
+      {% url 'faq' as faq_url %}
       {% blocktrans trimmed %}
-        <a href="{{ get_help_link }}">Get help</a> if you’re having difficulties requesting access or signing in.
+        <a href="{{ faq_url }}">Get help</a> if you’re having difficulties requesting access or signing in.
       {% endblocktrans %}
     </p>
   </div>

--- a/mtp_cashbook/urls.py
+++ b/mtp_cashbook/urls.py
@@ -17,6 +17,7 @@ urlpatterns = i18n_patterns(
     url(r'^$', misc_views.LandingView.as_view(), name='home'),
 
     # miscellaneous views
+    url(r'^faq/$', misc_views.FAQView.as_view(), name='faq'),
     url(r'^ml-briefing/$', misc_views.MLBriefingConfirmationView.as_view(), name='ml-briefing-confirmation'),
     url(r'^ml-briefing/read/$', misc_views.MLBriefingView.as_view(), name='ml-briefing'),
     url(r'^policy-change/$', misc_views.PolicyChangeInfo.as_view(), name='policy-change'),


### PR DESCRIPTION
Added an FAQ page which user can refer to when he's not signed it.
The 'Get help' link when the user is not signed it will now take them
to this page instead of directly to the "Contact us".

⚠️ **NOTE**: This is based off [the GDS Design System branch/PR](https://github.com/ministryofjustice/money-to-prisoners-cashbook/pull/537).

Ticket: https://dsdmoj.atlassian.net/browse/MTP-1834