### PR TITLE
MTP-1838: Simplify 'Contact us' form

### DIFF
--- a/mtp_cashbook/apps/feedback/forms.py
+++ b/mtp_cashbook/apps/feedback/forms.py
@@ -1,10 +1,22 @@
+from django import forms
 from django.utils.text import slugify
+from django.utils.translation import gettext_lazy as _
 from mtp_common.auth.exceptions import Unauthorized
 from slumber.exceptions import HttpClientError
 from zendesk_tickets.forms import EmailTicketForm
 
 
 class PrisonTicketForm(EmailTicketForm):
+
+    ticket_content = forms.CharField(
+        label=_('Please give details'),
+        widget=forms.Textarea,
+    )
+
+    contact_email = forms.EmailField(
+        label=_('Your email address'), required=True,
+    )
+
     def submit_ticket(self, request, subject, tags, ticket_template_name, **kwargs):
         try:
             accessible_prisons = sorted(prison['name'] for prison in request.user.user_data.get('prisons', []))

--- a/mtp_cashbook/templates/mtp_common/feedback/submit_feedback.html
+++ b/mtp_cashbook/templates/mtp_common/feedback/submit_feedback.html
@@ -1,0 +1,6 @@
+{% extends 'mtp_common/feedback/submit_feedback.html' %}
+
+
+{% block get_help_leading %}
+  {# This removes the lead paragraph above textarea #}
+{% endblock %}


### PR DESCRIPTION
- Remove lead paragraph
- Changed textarea label to 'Please give details'

Also
- Made 'Your email address' field mandatory.

Ticket: https://dsdmoj.atlassian.net/browse/MTP-1838

**NOTE**: As part of this ticket we're reviewing the exact copy of the pre-populated text which comes from the FAQ. This is independent from this change set and I could either add to this PR later on or make that change in a separate PR.