### PR TITLE
Update app build, deploy and cleanup pipelines to use `main` as the default branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
             echo "Pushing ${tag} to ECR"
             docker tag ${tag} ${registry}:${tag}
             docker push ${registry}:${tag}
-            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
+            if [[ "${CIRCLE_BRANCH}" == "main" ]]; then
               echo "Pushing ${app} to ECR (acts as latest)"
               docker tag ${tag} ${registry}:${app}
               docker push ${registry}:${app}
@@ -90,7 +90,7 @@ jobs:
       - deploy:
           name: Deploy to test
           command: |
-            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
+            if [[ "${CIRCLE_BRANCH}" == "main" ]]; then
               source /tmp/mtp-env.sh
               echo "Deploying to test"
 
@@ -125,7 +125,7 @@ jobs:
             IMAGES_TO_DELETE=$(aws ecr list-images --repository-name prisoner-money/money-to-prisoners --filter tagStatus=UNTAGGED --query 'imageIds[*].imageDigest' --output text)
             delete_images
 
-            if [[ "${CIRCLE_BRANCH}" != "master" ]]; then
+            if [[ "${CIRCLE_BRANCH}" != "main" ]]; then
               echo "Deleting other images from branch ${CIRCLE_BRANCH}"
               IMAGES_TO_DELETE=$(aws ecr describe-images --repository-name prisoner-money/money-to-prisoners --query 'imageDetails[?contains(map(&starts_with(@, '"'"${app}.${CIRCLE_BRANCH_LOWERCASE}."'"'), @.imageTags), `true`) && ! contains(@.imageTags, '"'"${tag}"'"')].imageDigest' --output text)
               delete_images

--- a/.github/actions/clean-ecr/entrypoint.py
+++ b/.github/actions/clean-ecr/entrypoint.py
@@ -43,7 +43,7 @@ def get_pull_request_branch():
     head_branch = pull_request.get('head', {}).get('ref')
     assert head_branch, 'Cannot determine branch'
     default_branch = pull_request.get('repository', {}).get('default_branch')
-    protected_branches = {'master', default_branch}
+    protected_branches = {'main', default_branch}
     assert head_branch not in protected_branches, f'Branch {head_branch} is protected'
     return head_branch
 

--- a/.github/workflows/clean-ecr.yml
+++ b/.github/workflows/clean-ecr.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
       - name: Delete branch images from ECR
         uses: ./.github/actions/clean-ecr
         env:


### PR DESCRIPTION
Depends on [mtp-deploy#352](https://github.com/ministryofjustice/money-to-prisoners-deploy/pull/352)