### PR TITLE
MTP-1925: Processed credits forms show last month by default

### DIFF
--- a/mtp_cashbook/apps/cashbook/tests/test_views.py
+++ b/mtp_cashbook/apps/cashbook/tests/test_views.py
@@ -16,6 +16,7 @@ from cashbook.tests import (
     MTPBaseTestCase,
     wrap_response_data,
 )
+from mtp_cashbook.utils import one_month_ago
 
 CREDIT_1 = {
     'id': 1,
@@ -900,12 +901,15 @@ class ProcessedCreditsDetailViewTestCase(MTPBaseTestCase):
         with responses.RequestsMock() as rsps:
             self.login()
 
+            default_start = one_month_ago().strftime('%Y-%m-%d')
+
             rsps.add(
                 rsps.GET,
                 api_url(
                     '/credits/?logged_at__gte=2017-06-03+00:00:00&limit=100'
                     '&logged_at__lt=2017-06-04+00:00:00&user=1'
                     '&log__action=credited&offset=0&ordering=-received_at'
+                    f'&received_at__gte={default_start}&page=1'
                 ),
                 json={
                     'count': 2,
@@ -954,12 +958,15 @@ class ProcessedCreditsDetailViewTestCase(MTPBaseTestCase):
         with responses.RequestsMock() as rsps:
             self.login()
 
+            default_start = one_month_ago().strftime('%Y-%m-%d')
+
             rsps.add(
                 rsps.GET,
                 api_url(
                     '/credits/?logged_at__gte=2017-06-03+00:00:00&limit=100'
                     '&logged_at__lt=2017-06-04+00:00:00&user=1'
                     '&log__action=credited&offset=0&ordering=-received_at'
+                    f'&received_at__gte={default_start}&page=1'
                 ),
                 json={
                     'count': 0,

--- a/mtp_cashbook/apps/cashbook/views.py
+++ b/mtp_cashbook/apps/cashbook/views.py
@@ -227,7 +227,7 @@ class ProcessedCreditsListView(CashbookView, FormView):
         initial = super().get_initial()
         initial.update({
             'page': 1,
-            'start': one_month_ago(),
+            'start': one_month_ago().strftime('%d/%m/%Y'),
         })
 
         return initial
@@ -298,7 +298,7 @@ class SearchView(CashbookView, FormView):
         initial = super().get_initial()
         initial.update({
             'page': 1,
-            'start': one_month_ago(),
+            'start': one_month_ago().strftime('%d/%m/%Y'),
         })
 
         return initial

--- a/mtp_cashbook/apps/cashbook/views.py
+++ b/mtp_cashbook/apps/cashbook/views.py
@@ -233,12 +233,12 @@ class ProcessedCreditsListView(CashbookView, FormView):
         return initial
 
     def get_form_kwargs(self):
-        return {
-            'request': self.request,
-            'data': self.request.GET or {},
-            'initial': self.get_initial(),
-            'prefix': self.get_prefix(),
-        }
+        kwargs = super().get_form_kwargs()
+        request_data = self.get_initial()
+        request_data.update(self.request.GET.dict())
+        kwargs['data'] = request_data
+        kwargs['request'] = self.request
+        return kwargs
 
     def get(self, request, *args, **kwargs):
         form = self.get_form()
@@ -304,12 +304,12 @@ class SearchView(CashbookView, FormView):
         return initial
 
     def get_form_kwargs(self):
-        return {
-            'request': self.request,
-            'data': self.request.GET or {},
-            'initial': self.get_initial(),
-            'prefix': self.get_prefix(),
-        }
+        kwargs = super().get_form_kwargs()
+        request_data = self.get_initial()
+        request_data.update(self.request.GET.dict())
+        kwargs['data'] = request_data
+        kwargs['request'] = self.request
+        return kwargs
 
     def get(self, request, *args, **kwargs):
         form = self.get_form()

--- a/mtp_cashbook/apps/cashbook/views.py
+++ b/mtp_cashbook/apps/cashbook/views.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 
 from django.conf import settings
@@ -21,6 +21,10 @@ from feedback.views import GetHelpView, GetHelpSuccessView
 from mtp_cashbook.misc_views import BaseView
 
 logger = logging.getLogger('mtp')
+
+
+def one_month_ago():
+    return datetime.today() - timedelta(days=30)
 
 
 class CashbookView(BaseView):
@@ -226,7 +230,9 @@ class ProcessedCreditsListView(CashbookView, FormView):
         initial = super().get_initial()
         initial.update({
             'page': 1,
+            'start': one_month_ago(),
         })
+
         return initial
 
     def get_form_kwargs(self):
@@ -295,7 +301,9 @@ class SearchView(CashbookView, FormView):
         initial = super().get_initial()
         initial.update({
             'page': 1,
+            'start': one_month_ago(),
         })
+
         return initial
 
     def get_form_kwargs(self):

--- a/mtp_cashbook/apps/cashbook/views.py
+++ b/mtp_cashbook/apps/cashbook/views.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 import logging
 
 from django.conf import settings
@@ -19,12 +19,9 @@ from cashbook.forms import (
 )
 from feedback.views import GetHelpView, GetHelpSuccessView
 from mtp_cashbook.misc_views import BaseView
+from mtp_cashbook.utils import one_month_ago
 
 logger = logging.getLogger('mtp')
-
-
-def one_month_ago():
-    return datetime.today() - timedelta(days=30)
 
 
 class CashbookView(BaseView):

--- a/mtp_cashbook/apps/disbursements/tests/test_search.py
+++ b/mtp_cashbook/apps/disbursements/tests/test_search.py
@@ -6,6 +6,7 @@ import responses
 
 from cashbook.tests import MTPBaseTestCase, api_url
 from disbursements.forms import SearchForm
+from mtp_cashbook import utils
 
 
 class DisbursementSearchViewTextCase(MTPBaseTestCase):
@@ -75,7 +76,12 @@ class DisbursementSearchViewTextCase(MTPBaseTestCase):
     def test_disbursements_search(self):
         self.login()
         with responses.RequestsMock() as rsps:
-            rsps.add(rsps.GET, api_url('/disbursements/?offset=10&limit=10&ordering=-created&resolution=confirmed',),
+            one_month_ago = utils.one_month_ago().strftime('%Y-%m-%d')
+            url = api_url(
+                '/disbursements/?offset=10&limit=10&ordering=-created&resolution=confirmed'
+                f'&log__action=confirmed&logged_at__gte={one_month_ago}'
+            )
+            rsps.add(rsps.GET, url,
                      match_querystring=True,
                      json={'count': 11, 'results': [{
                          'id': 99, 'amount': 25010, 'invoice_number': '1000099',

--- a/mtp_cashbook/apps/disbursements/views.py
+++ b/mtp_cashbook/apps/disbursements/views.py
@@ -763,7 +763,7 @@ class SearchView(DisbursementView, FormView):
     def get_initial(self):
         initial = super().get_initial()
         initial.update({
-            'date__gte': one_month_ago(),
+            'date__gte': one_month_ago().strftime('%d/%m/%Y'),
         })
 
         return initial

--- a/mtp_cashbook/apps/disbursements/views.py
+++ b/mtp_cashbook/apps/disbursements/views.py
@@ -20,6 +20,7 @@ from disbursements import forms as disbursement_forms
 from disbursements.utils import get_disbursement_viability, find_addresses
 from feedback.views import GetHelpView, GetHelpSuccessView
 from mtp_cashbook.misc_views import BaseView
+from mtp_cashbook.utils import one_month_ago
 
 logger = logging.getLogger('mtp')
 
@@ -758,6 +759,14 @@ class SearchView(DisbursementView, FormView):
     title = _('Payments made')
     url_name = 'search'
     form_class = disbursement_forms.SearchForm
+
+    def get_initial(self):
+        initial = super().get_initial()
+        initial.update({
+            'date__gte': one_month_ago(),
+        })
+
+        return initial
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/mtp_cashbook/templates/disbursements/search.html
+++ b/mtp_cashbook/templates/disbursements/search.html
@@ -80,7 +80,7 @@
         <div class="govuk-button-group">
           <button type="submit" class="govuk-button" data-module="govuk-button">{% trans 'Filter list' %}</button>
           {% if form.search_description.has_filters %}
-            <a href="?{% if form.ordering.value %}ordering={{ form.ordering.value }}{% endif %}" class="govuk-link" role="button">
+            <a href="?date__gte={% if form.ordering.value %}&ordering={{ form.ordering.value }}{% endif %}" class="govuk-link" role="button">
               {% trans 'Clear filters' %}
             </a>
           {% endif %}

--- a/mtp_cashbook/utils.py
+++ b/mtp_cashbook/utils.py
@@ -1,3 +1,5 @@
+import datetime
+
 from mtp_common.auth import USER_DATA_SESSION_KEY
 from mtp_common.auth.api_client import get_api_session
 
@@ -48,3 +50,7 @@ def merge_credit_notice_emails_with_user_prisons(credit_notice_emails, request):
         key=lambda credit_notice_email: credit_notice_email['prison_name'],
     )
     return credit_notice_emails
+
+
+def one_month_ago():
+    return datetime.datetime.today() - datetime.timedelta(days=30)

--- a/mtp_cashbook/utils.py
+++ b/mtp_cashbook/utils.py
@@ -53,4 +53,4 @@ def merge_credit_notice_emails_with_user_prisons(credit_notice_emails, request):
 
 
 def one_month_ago():
-    return datetime.datetime.today() - datetime.timedelta(days=30)
+    return datetime.date.today() - datetime.timedelta(days=30)


### PR DESCRIPTION
Currently all credits are shown by default which is slow and probably
adds more unnecessary pressure to the database.