### PR TITLE
MTP-1925: Clearing a form is lost when changing pages

### DIFF
--- a/mtp_cashbook/apps/cashbook/forms.py
+++ b/mtp_cashbook/apps/cashbook/forms.py
@@ -203,8 +203,10 @@ class FilterProcessedCreditsListForm(GARequestErrorReportingMixin, forms.Form):
             if field.name == 'page':
                 continue
             value = self.cleaned_data.get(field.name)
-            if value in [None, '', []]:
+            if value in ['', []]:
                 continue
+            if value is None:
+                value = ''
             data[field.name] = value
         return data
 

--- a/mtp_cashbook/apps/cashbook/forms.py
+++ b/mtp_cashbook/apps/cashbook/forms.py
@@ -203,8 +203,6 @@ class FilterProcessedCreditsListForm(GARequestErrorReportingMixin, forms.Form):
             if field.name == 'page':
                 continue
             value = self.cleaned_data.get(field.name)
-            if value in ['', []]:
-                continue
             if value is None:
                 value = ''
             data[field.name] = value
@@ -430,8 +428,8 @@ class SearchForm(GARequestErrorReportingMixin, forms.Form):
             if field.name == 'page':
                 continue
             value = self.cleaned_data.get(field.name)
-            if value in [None, '', []]:
-                continue
+            if value is None:
+                value = ''
             data[field.name] = value
         return data
 

--- a/mtp_cashbook/apps/disbursements/forms.py
+++ b/mtp_cashbook/apps/disbursements/forms.py
@@ -506,8 +506,6 @@ class BaseSearchForm(GARequestErrorReportingMixin, forms.Form):
             if field.name == 'page':
                 continue
             value = self.cleaned_data.get(field.name)
-            if value in ['', []]:
-                continue
             if value is None:
                 value = ''
             data[field.name] = value

--- a/mtp_cashbook/apps/disbursements/forms.py
+++ b/mtp_cashbook/apps/disbursements/forms.py
@@ -506,15 +506,17 @@ class BaseSearchForm(GARequestErrorReportingMixin, forms.Form):
             if field.name == 'page':
                 continue
             value = self.cleaned_data.get(field.name)
-            if value in [None, '', []]:
+            if value in ['', []]:
                 continue
+            if value is None:
+                value = ''
             data[field.name] = value
         return data
 
     def get_api_request_params(self):
         filters = self.get_query_data()
         for param in filters:
-            if param in self.exclusive_date_params:
+            if param in self.exclusive_date_params and filters[param]:
                 filters[param] += datetime.timedelta(days=1)
         return filters
 

--- a/mtp_cashbook/apps/disbursements/tests/test_search.py
+++ b/mtp_cashbook/apps/disbursements/tests/test_search.py
@@ -148,12 +148,19 @@ class DisbursementSearchFormTextCase(SimpleTestCase):
         })
         self.assertTrue(form.is_valid())
         query_params = form.get_api_request_params()
-        query_params.pop('resolution', None)
         self.assertDictEqual(query_params, {
             'ordering': '-created',
             'log__action': 'created',
             'logged_at__gte': datetime.date(2018, 1, 10),
             'logged_at__lt': datetime.date(2018, 1, 12),
+            # emtpy input field default values:
+            'prisoner_name': '',
+            'prisoner_number': '',
+            'recipient_name': '',
+            'nomis_transaction_id': '',
+            'invoice_number': '',
+            'resolution': ['confirmed', 'sent'],
+            'method': '',
         })
         description = form.search_description
         self.assertTrue(description['has_filters'])
@@ -166,11 +173,18 @@ class DisbursementSearchFormTextCase(SimpleTestCase):
         })
         self.assertTrue(form.is_valid())
         query_params = form.get_api_request_params()
-        query_params.pop('resolution', None)
         self.assertDictEqual(query_params, {
             'ordering': '-amount',
             'log__action': 'confirmed',
             'logged_at__lt': datetime.date(2018, 1, 11),
+            # emtpy input field default values:
+            'prisoner_name': '',
+            'prisoner_number': '',
+            'recipient_name': '',
+            'nomis_transaction_id': '',
+            'invoice_number': '',
+            'resolution': ['confirmed', 'sent'],
+            'method': '',
         })
         description = form.search_description
         self.assertTrue(description['has_filters'])


### PR DESCRIPTION
Clear a form default date means that query parameter is set blank.
Unfortunately these blank query params were ignored (we think this may be
to make the URL look cleaner)

Removing the logic that removes `None` query params should fix this issue.