### PR TITLE
MTP-1937: Stop trying to send data to legacy GA

### DIFF
--- a/mtp_cashbook/assets-src/components/cashbook/batch-validation.js
+++ b/mtp_cashbook/assets-src/components/cashbook/batch-validation.js
@@ -59,7 +59,6 @@ export var BatchValidation = {
       e.preventDefault();
       $('#incomplete-batch-dialogue').trigger('dialogue:open');
       var pageLocation = '/batch/-dialog_open/';
-      Analytics.send('pageview', pageLocation);
       Analytics.ga4SendPageView(pageLocation);
     }
   }

--- a/mtp_cashbook/settings/base.py
+++ b/mtp_cashbook/settings/base.py
@@ -268,7 +268,6 @@ OAUTHLIB_INSECURE_TRANSPORT = True
 REQUEST_PAGE_SIZE = 100
 
 ANALYTICS_REQUIRED = os.environ.get('ANALYTICS_REQUIRED', 'True') == 'True'
-GOOGLE_ANALYTICS_ID = os.environ.get('GOOGLE_ANALYTICS_ID', None)
 GA4_MEASUREMENT_ID = os.environ.get('GA4_MEASUREMENT_ID', None)
 
 ZENDESK_BASE_URL = 'https://ministryofjustice.zendesk.com'


### PR DESCRIPTION
- removed setting
- removed call to now deprecated `Analytics.js`'s legacy GA `.send()`