### PR TITLE
IR-1734 Require money-to-prisoners-common 21.2.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=21.2.1
+money-to-prisoners-common~=21.2.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=21.2.1
+money-to-prisoners-common[testing]~=21.2.6
 
 -r base.txt


### PR DESCRIPTION
## What
Pin `money-to-prisoners-common` to `~=21.2.6` so the built image includes the ServiceNow password-reset changes.

## Why
The password-reset links added in IR-1734 rely on the `servicenow_password_reset_url` context variable introduced in money-to-prisoners-common **21.2.6**. The previous `~=21.2.1` pin did not change the `requirements` files, so Docker layer caching reused the cached pip-install layer (common 21.2.5) and the built image did not include the new variable. Bumping the pin busts that cache and guarantees 21.2.6 is installed.

## Follow-up
Merging auto-deploys to test; verify the 'Forgotten your password?' link points to ServiceNow.