### PR TITLE
IR-1755 Bump money-to-prisoners-common to 21.2.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
 # Dependencies needed for all environments
 
-money-to-prisoners-common~=21.2.6
+money-to-prisoners-common~=21.2.7

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 # Place development and testing dependencies here
 
-money-to-prisoners-common[testing]~=21.2.6
+money-to-prisoners-common[testing]~=21.2.7
 
 -r base.txt


### PR DESCRIPTION
Picks up common **21.2.7**, which reverts jquery from `~4.0` back to `~3.7`.

### Why
jquery 4.0 ships as an ESM-only package, so webpack's `ProvidePlugin({ $: 'jquery' })` bound the global `$` to the module *namespace object* instead of the jquery function. `$(...)` then threw `TypeError: $ is not a function` in the first module initialised (`Analytics.init`), and because the init sequences have no try/catch that one throw aborted **every** subsequent module init — breaking all page JS, including the cashbook **"Select all"** credits checkbox (reported on live and test).

### Change
Bump the pin `~=21.2.6` → `~=21.2.7` in `base.txt` and `dev.txt` so the build resolves at least the fix release. Rebuilding the image against 21.2.7 links jquery 3.7.1, restoring a callable `$` (and `$.proxy`).

Follow-up (separate ticket): proper jquery 4 migration (fix `ProvidePlugin` + replace removed APIs `$.proxy`/`$.isArray`/`$.trim`/`.size()`).