### PR TITLE
IR-1782 Dual-push cashbook images to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,10 @@
 node_modules/
 npm-debug.log
 
+# local developer settings, which may hold real credentials; gitignored, but a local
+# `docker build` would otherwise bake them into an image that is now published publicly
+**/settings/local.py
+
 # project
 Dockerfile
 docker-compose.yml

--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -9,12 +9,13 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
       - name: Assume IAM role to access ECR
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.ECR_REGION }}
           role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
@@ -23,6 +24,13 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Log docker into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Compute image tags
         id: tags
         run: |
@@ -30,18 +38,23 @@ jobs:
           version=${branch_lc}.${GITHUB_SHA::7}
           tag=cashbook.${version}
           registry=${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}
-          echo "branch_lc=${branch_lc}" >> "$GITHUB_OUTPUT"
-          echo "version=${version}"     >> "$GITHUB_OUTPUT"
-          echo "tag=${tag}"             >> "$GITHUB_OUTPUT"
-          echo "registry=${registry}"   >> "$GITHUB_OUTPUT"
+          ghcr_package=ghcr.io/${{ github.repository_owner }}/money-to-prisoners-cashbook
+          ghcr_base=ghcr.io/${{ github.repository_owner }}/money-to-prisoners-base
+          echo "branch_lc=${branch_lc}"         >> "$GITHUB_OUTPUT"
+          echo "version=${version}"             >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}"                     >> "$GITHUB_OUTPUT"
+          echo "registry=${registry}"           >> "$GITHUB_OUTPUT"
+          echo "ghcr_package=${ghcr_package}"   >> "$GITHUB_OUTPUT"
+          echo "ghcr_base=${ghcr_base}"         >> "$GITHUB_OUTPUT"
           echo "Building ${tag}"
 
+      # base images come from the public GHCR package, so this needs no credentials
       - name: Pull base image
         env:
-          REGISTRY: ${{ steps.tags.outputs.registry }}
+          GHCR_BASE: ${{ steps.tags.outputs.ghcr_base }}
         run: |
-          docker pull ${REGISTRY}:base-web
-          docker tag ${REGISTRY}:base-web base-web
+          docker pull ${GHCR_BASE}:base-web
+          docker tag ${GHCR_BASE}:base-web base-web
 
       - name: Build docker image
         env:
@@ -83,15 +96,23 @@ jobs:
       - name: Push docker image
         env:
           TAG: ${{ steps.tags.outputs.tag }}
+          VERSION: ${{ steps.tags.outputs.version }}
           REGISTRY: ${{ steps.tags.outputs.registry }}
+          GHCR_PACKAGE: ${{ steps.tags.outputs.ghcr_package }}
         run: |
           echo "Pushing ${TAG} to ECR"
           docker tag ${TAG} ${REGISTRY}:${TAG}
           docker push ${REGISTRY}:${TAG}
+          echo "Pushing ${VERSION} to GHCR ${GHCR_PACKAGE}"
+          docker tag ${TAG} ${GHCR_PACKAGE}:${VERSION}
+          docker push ${GHCR_PACKAGE}:${VERSION}
           if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
             echo "Pushing cashbook to ECR (acts as latest)"
             docker tag ${TAG} ${REGISTRY}:cashbook
             docker push ${REGISTRY}:cashbook
+            echo "Pushing latest to GHCR"
+            docker tag ${TAG} ${GHCR_PACKAGE}:latest
+            docker push ${GHCR_PACKAGE}:latest
           fi
 
       


### PR DESCRIPTION
Phase 2 pilot for IR-1782 — moving MTP images off the private ECR onto public
GHCR packages. Cashbook goes first; the other four follow once this is green.

Generated from ministryofjustice/money-to-prisoners-deploy#523 — **do not hand-edit**,
change the template there.

## What changes

- Pushes to ECR **exactly as before**, and additionally to
  `ghcr.io/ministryofjustice/money-to-prisoners-cashbook`, tagged
  `[branch].[sha]` plus `latest` on `main`. The `cashbook.` tag prefix is not
  needed on GHCR because the package name carries it.
- The **base image now comes from the public
  `ghcr.io/ministryofjustice/money-to-prisoners-base` package**, so that pull
  needs no credentials.
- **Deploys are unchanged** — `Deploy to test` still uses the ECR image. Moving
  deploys to GHCR is a later phase.

## Why this matters

The private ECR means `docker-compose up` cannot work without AWS credentials
(every `Dockerfile-dev` starts `FROM ${ECR_REGISTRY}/…`), and Veracode and other
scanners cannot reach the built images at all.

## Also in this PR

**`**/settings/local.py` is excluded from the docker build context.** It is
gitignored so CI is unaffected, but a local `docker build` would otherwise bake a
developer's own settings — possibly real credentials — into an image that is now
published publicly. Verified by dropping a decoy `local.py` in place, building the
context and confirming both the file and its contents are absent, while
`local.py.sample` and the real settings modules remain.

**The regeneration also picks up `configure-aws-credentials` v5 → v6**, which this
repo had drifted behind the template on. Unrelated to IR-1782, but it comes along
with regenerating from the template.

## After merge

The push to `main` publishes the first cashbook image to GHCR. The package is
created **private**; it then needs making **public** and linking to this repo,
same as was done for `money-to-prisoners-base`.
