### PR TITLE
IR-1782 Fix the container scan and sweep up orphaned branch images

### DIFF
--- a/.github/scripts/clean-ghcr.py
+++ b/.github/scripts/clean-ghcr.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python
 """
-Delete this repository's branch images from GHCR once their pull request closes
+Delete this repository's branch images from GHCR
 
 Branch builds are tagged `[branch].[commit]` and are never deployed after the pull request
 ends, but GHCR - unlike ECR - has no lifecycle policy, so nothing removes them otherwise.
+
+Two modes, because closing a pull request is not enough on its own:
+
+- on a closed pull request, delete that branch's images
+- on a schedule, delete images for any branch that no longer exists
+
+The sweep exists because a pull request merged while its own build is still running is
+cleaned up before that build pushes its image, leaving the image behind for good.
 
 Runs on the github runner with the repository's own GITHUB_TOKEN: a package can only be
 administered by a token from the repository it is linked to.
@@ -11,6 +19,7 @@ administered by a token from the repository it is linked to.
 import json
 import logging
 import os
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -18,34 +27,87 @@ import urllib.request
 logger = logging.getLogger(__name__)
 
 API_ROOT = 'https://api.github.com'
+# the `[commit]` half of a `[branch].[commit]` image tag
+COMMIT_RE = re.compile(r'^[0-9a-f]{7,40}$')
 
 
 def clean_ghcr():
     organisation, package = os.environ['GITHUB_REPOSITORY'].split('/', 1)
-    branch = get_pull_request_branch()
-    prefix = f'{branch}.'
-
     versions = list_versions(organisation, package)
     logger.info(f'{package} has {len(versions)} version(s)')
 
-    deletable = []
-    for version_id, tags in versions:
-        if not tags:
-            # untagged versions are usually a superseded build or an attestation, but a
-            # multi-arch child manifest is also untagged, so leave them to the base cleanup
-            continue
-        # every tag must belong to this branch: a digest also tagged `latest` is in use
-        if all(tag.startswith(prefix) for tag in tags):
-            deletable.append((version_id, tags))
+    if os.environ.get('GITHUB_EVENT_NAME') == 'pull_request':
+        branch = get_pull_request_branch()
+        deletable = versions_for_branches(versions, {branch})
+        described = f'branch {branch}'
+    else:
+        live_branches = {branch.lower() for branch in list_branches(organisation, package)}
+        logger.info(f'{len(live_branches)} branch(es) still exist')
+        deletable = versions_for_deleted_branches(versions, live_branches)
+        described = 'deleted branches'
 
     if not deletable:
-        logger.info(f'No images tagged {prefix}*')
+        logger.info(f'No images to delete for {described}')
         return
 
-    logger.info(f'Deleting {len(deletable)} image(s) tagged {prefix}*')
+    logger.info(f'Deleting {len(deletable)} image(s) for {described}')
     for version_id, tags in deletable:
         logger.info(f'  {", ".join(tags)}')
         delete_version(organisation, package, version_id)
+
+
+def versions_for_branches(versions, branches):
+    """
+    Versions whose every tag belongs to one of `branches`
+    """
+    prefixes = tuple(f'{branch}.' for branch in branches)
+    return [
+        (version_id, tags)
+        # a version with no tag at all is a superseded build or an attestation, and one
+        # tagged `latest` as well is in use, so neither is matched here
+        for version_id, tags in versions
+        if tags and all(tag.startswith(prefixes) for tag in tags)
+    ]
+
+
+def versions_for_deleted_branches(versions, live_branches):
+    """
+    Versions whose every tag belongs to a branch that no longer exists
+
+    NB: `main` always exists, so versions still deployed from it are never matched. Anything
+    whose branch cannot be determined is left alone.
+    """
+    deletable = []
+    for version_id, tags in versions:
+        if not tags:
+            continue
+        branches = set()
+        for tag in tags:
+            branch, _, commit = tag.rpartition('.')
+            if not (branch and COMMIT_RE.match(commit)):
+                # a tag such as `latest` names no branch, so this version is in use
+                break
+            branches.add(branch)
+        else:
+            if not (branches & live_branches):
+                deletable.append((version_id, tags))
+    return deletable
+
+
+def list_branches(organisation, repository):
+    """
+    Every branch that still exists in the repository
+    """
+    branches, page = [], 1
+    while True:
+        body = github_api(f'/repos/{organisation}/{repository}/branches?per_page=100&page={page}')
+        if not body:
+            break
+        branches.extend(branch['name'] for branch in body)
+        if len(body) < 100:
+            break
+        page += 1
+    return branches
 
 
 def get_pull_request_branch():

--- a/.github/workflows/clean-ghcr.yml
+++ b/.github/workflows/clean-ghcr.yml
@@ -5,6 +5,11 @@ on:
     # clean up branch images when a PR is closed
     types:
       - closed
+  workflow_dispatch:
+  schedule:
+    # A PR merged while its own build is still running is cleaned up before that build
+    # pushes its image, so sweep up anything left behind by a branch that has since gone.
+    - cron: '21 3 * * 1'
 jobs:
   clean-ghcr:
     name: Clean GHCR
@@ -18,7 +23,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: main
-
       - name: Delete branch images from GHCR
         run: python3 .github/scripts/clean-ghcr.py
         env:

--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -12,6 +12,7 @@ jobs:
       contents: read
       actions: read
       security-events: write
+      id-token: write
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_snyk_scan_ecr.yml@v2 # WORKFLOW_VERSION
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}


### PR DESCRIPTION
Part of IR-1782. Generated from `money-to-prisoners-deploy` ([#544](https://github.com/ministryofjustice/money-to-prisoners-deploy/pull/544), [#545](https://github.com/ministryofjustice/money-to-prisoners-deploy/pull/545)). Two fixes, both found by checking what the last round actually did rather than assuming.

## The container scan has never run

It fails at startup in every repo, reported only as *"This run likely failed because of a workflow file issue"* — no annotation, no job log.

A caller's `permissions` block caps what a called workflow may request, and the shared MoJ workflow's job asks for `id-token: write`, which was not granted.

Verified by dispatching the same workflow with and without the fix — `startup_failure` against `main`, `success` against the branch — and it does real work rather than skipping:

```
Testing ghcr.io/ministryofjustice/money-to-prisoners-cashbook:latest...
Tested 514 dependencies for known issues, no vulnerable paths found.
```

It pulls the image anonymously, with no registry credentials.

## Branch cleanup misses images when a merge races its own build

Cleaning up on PR close is not enough on its own. A PR merged while its build is still running is cleaned up *before* that build pushes its image, orphaning it permanently.

This happened on the previous round of PRs. In noms-ops:

```
Clean GHCR          11:22:08 -> 11:22:18   "No images tagged ir-1782-ghcr-branch-cleanup.*"
Build, test, push   11:18:15 -> 11:23:48   pushed ir-1782-ghcr-branch-cleanup.4eb33c8
```

Seven of eight repos cleaned up correctly; noms-ops lost by 90 seconds.

So this adds a weekly sweep removing images for branches that no longer exist, catching anything the close-time cleanup misses regardless of cause. Checked against real package and branch data:

- `main` always exists, so `main.*` versions are never matched — including the ones prod is running
- a version carrying a tag that names no branch (`latest`) is always left alone
- the commit half of a tag must look like a commit, so unexpected tag shapes are skipped rather than guessed at

Schedules are staggered per repo.

Nothing stops being pushed to ECR in this PR.
